### PR TITLE
tweak: improve read-only collateral function in auction engine with traits

### DIFF
--- a/clarity/contracts/arkadiko-auction-engine-trait-v1.clar
+++ b/clarity/contracts/arkadiko-auction-engine-trait-v1.clar
@@ -3,8 +3,7 @@
 
 (define-trait auction-engine-trait
   (
-    ;; make this part of the trait when bug is fixed: (get-minimum-collateral-amount (<oracle-trait> uint) (response uint bool))
-    (fetch-minimum-collateral-amount (<oracle-trait> uint) (response uint uint))
+    (get-minimum-collateral-amount (<oracle-trait> uint) (response uint uint))
     (start-auction (uint uint uint uint uint) (response bool uint))
   )
 )

--- a/clarity/tests/models/arkadiko-tests-vaults.ts
+++ b/clarity/tests/models/arkadiko-tests-vaults.ts
@@ -132,7 +132,7 @@ class VaultManager {
 
   fetchMinimumCollateralAmount(auctionId: number, caller: Account = this.deployer) {
     let block = this.chain.mineBlock([
-      Tx.contractCall("arkadiko-auction-engine-v1-1", "fetch-minimum-collateral-amount", [
+      Tx.contractCall("arkadiko-auction-engine-v1-1", "get-minimum-collateral-amount", [
         types.principal('STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-oracle-v1-1'),
         types.uint(auctionId)
       ], caller.address),

--- a/web/components/auction.tsx
+++ b/web/components/auction.tsx
@@ -43,7 +43,7 @@ export const Auction: React.FC<AuctionProps> = ({ id, lotId, collateralToken, en
       const minimumCollateralAmount = await callReadOnlyFunction({
         contractAddress,
         contractName: "arkadiko-auction-engine-v1-1",
-        functionName: "calculate-minimum-collateral-amount",
+        functionName: "get-minimum-collateral-amount",
         functionArgs: [uintCV(price), uintCV(id)],
         senderAddress: stxAddress || '',
         network: network,


### PR DESCRIPTION
This fixes the read-only issue we had when passing a trait as a parameter. The function would always be marked as a write function within the Stacks blockchain.

@nieldeckx Now we can tackle https://trello.com/c/Jnh3V5EX/67-clear-out-all-static-contract-call-invocations-for-which-a-trait-exists - I might do that in the coming week before testnet still.