### PR TITLE
Chore: update clarinet 0.13.0

### DIFF
--- a/clarity/tests/arkadiko-auction-engine-v1-1_test.ts
+++ b/clarity/tests/arkadiko-auction-engine-v1-1_test.ts
@@ -4,7 +4,7 @@ import {
   Clarinet,
   Tx,
   types,
-} from "https://deno.land/x/clarinet@v0.10.0/index.ts";
+} from "https://deno.land/x/clarinet@v0.13.0/index.ts";
 
 import { 
   OracleManager,

--- a/clarity/tests/arkadiko-diko-guardian-v1-1_test.ts
+++ b/clarity/tests/arkadiko-diko-guardian-v1-1_test.ts
@@ -4,7 +4,7 @@ import {
   Clarinet,
   Tx,
   types,
-} from "https://deno.land/x/clarinet@v0.10.0/index.ts";
+} from "https://deno.land/x/clarinet@v0.13.0/index.ts";
 
 Clarinet.test({
 name: "diko-guardian: print staking distribution",

--- a/clarity/tests/arkadiko-diko-init_test.ts
+++ b/clarity/tests/arkadiko-diko-init_test.ts
@@ -4,7 +4,7 @@ import {
   Clarinet,
   Tx,
   types,
-} from "https://deno.land/x/clarinet@v0.10.0/index.ts";
+} from "https://deno.land/x/clarinet@v0.13.0/index.ts";
 
 
 Clarinet.test({

--- a/clarity/tests/arkadiko-freddie-v1-1_test.ts
+++ b/clarity/tests/arkadiko-freddie-v1-1_test.ts
@@ -4,7 +4,7 @@ import {
   Clarinet,
   Tx,
   types,
-} from "https://deno.land/x/clarinet@v0.10.0/index.ts";
+} from "https://deno.land/x/clarinet@v0.13.0/index.ts";
 
 import { 
   OracleManager,

--- a/clarity/tests/arkadiko-freddie-v1-1_test.ts
+++ b/clarity/tests/arkadiko-freddie-v1-1_test.ts
@@ -243,7 +243,7 @@ Clarinet.test({
     result = vaultManager.payStabilityFee(deployer, 1);
  
     call = vaultManager.getStabilityFee(1, deployer);
-    call.result.expectOk().expectUint(19); // ~$0
+    call.result.expectOk().expectUint(1918);
 
     call = await vaultManager.getVaultById(1, deployer);
     vault = call.result.expectTuple();

--- a/clarity/tests/arkadiko-governance-v1-1_test.ts
+++ b/clarity/tests/arkadiko-governance-v1-1_test.ts
@@ -4,7 +4,7 @@ import {
   Clarinet,
   Tx,
   types,
-} from "https://deno.land/x/clarinet@v0.10.0/index.ts";
+} from "https://deno.land/x/clarinet@v0.13.0/index.ts";
 
 Clarinet.test({
   name: "governance: add proposal and test proposal data",

--- a/clarity/tests/arkadiko-liquidator-v1-1_test.ts
+++ b/clarity/tests/arkadiko-liquidator-v1-1_test.ts
@@ -4,7 +4,7 @@ import {
   Clarinet,
   Tx,
   types,
-} from "https://deno.land/x/clarinet@v0.10.0/index.ts";
+} from "https://deno.land/x/clarinet@v0.13.0/index.ts";
 
 Clarinet.test({
   name:

--- a/clarity/tests/arkadiko-sip10-reserve-v1-1_test.ts
+++ b/clarity/tests/arkadiko-sip10-reserve-v1-1_test.ts
@@ -4,7 +4,7 @@ import {
   Clarinet,
   Tx,
   types,
-} from "https://deno.land/x/clarinet@v0.10.0/index.ts";
+} from "https://deno.land/x/clarinet@v0.13.0/index.ts";
 import { assert } from "https://deno.land/std@0.90.0/testing/asserts.ts";
 
 // 

--- a/clarity/tests/arkadiko-stacker-v1-1_test.ts
+++ b/clarity/tests/arkadiko-stacker-v1-1_test.ts
@@ -4,7 +4,7 @@ import {
   Clarinet,
   Tx,
   types,
-} from "https://deno.land/x/clarinet@v0.10.0/index.ts";
+} from "https://deno.land/x/clarinet@v0.13.0/index.ts";
 
 Clarinet.test({
   name: "stacker: initiate stacking in PoX contract with enough STX tokens",

--- a/clarity/tests/arkadiko-stake-registry-v1-1_test.ts
+++ b/clarity/tests/arkadiko-stake-registry-v1-1_test.ts
@@ -4,7 +4,7 @@ import {
     Clarinet,
     Tx,
     types,
-} from "https://deno.land/x/clarinet@v0.10.0/index.ts";
+} from "https://deno.land/x/clarinet@v0.13.0/index.ts";
 
 import { 
   OracleManager

--- a/clarity/tests/arkadiko-stake-registry-v1-1_test.ts
+++ b/clarity/tests/arkadiko-stake-registry-v1-1_test.ts
@@ -200,7 +200,7 @@ async fn(chain: Chain, accounts: Map<string, Account>) {
 
   // Total staked 100 + 200 = 300
   call = chain.callReadOnlyFn("arkadiko-stake-pool-diko-v1-1", "get-total-staked", [], wallet_1.address);
-  call.result.expectUint(300);
+  call.result.expectUint(300000000);
 
   // First blocks have 626 rewards. Start cumm reward: 626 / 100 = 6.26
   // 4 blocks later: 4 * 6.26 = 25.04
@@ -507,7 +507,7 @@ async fn(chain: Chain, accounts: Map<string, Account>) {
     ], wallet_1.address)
   ]);
   // Can not burn 0 tokens
-  block.receipts[0].result.expectErr().expectUint(1);
+  block.receipts[0].result.expectErr().expectUint(18003);
 }
 });
 

--- a/clarity/tests/arkadiko-swap-v1-1_test.ts
+++ b/clarity/tests/arkadiko-swap-v1-1_test.ts
@@ -36,8 +36,8 @@ Clarinet.test({
 
     // Check initial balances
     let call = await swap.getBalances(dikoTokenAddress, xusdTokenAddress);
-    call.result.expectOk().expectList()[0].expectUint(500);
-    call.result.expectOk().expectList()[1].expectUint(100);
+    call.result.expectOk().expectList()[0].expectUint(500000000);
+    call.result.expectOk().expectList()[1].expectUint(100000000);
 
     // Add extra lquidity
     result = swap.addToPosition(deployer, dikoTokenAddress, xusdTokenAddress, dikoXusdPoolAddress, 500, 0);
@@ -45,21 +45,21 @@ Clarinet.test({
 
     // Check new balances (both tokens should have increased, price remains the same)
     call = await swap.getBalances(dikoTokenAddress, xusdTokenAddress);
-    call.result.expectOk().expectList()[0].expectUint(1000);
-    call.result.expectOk().expectList()[1].expectUint(200);
+    call.result.expectOk().expectList()[0].expectUint(1000000000);
+    call.result.expectOk().expectList()[1].expectUint(200000000);
 
     // Check if tracked balances is the same as tokens owned by contract
     call = await chain.callReadOnlyFn("arkadiko-token", "get-balance", [
       types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-swap-v1-1"),
     ], deployer.address);
-    call.result.expectOk().expectUint(1000);
+    call.result.expectOk().expectUint(1000000000);
     call = await xusdManager.balanceOf("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-swap-v1-1");
-    call.result.expectOk().expectUint(200);
+    call.result.expectOk().expectUint(200000000);
 
     // Remove other 90% of liquidity
     result = swap.reducePosition(deployer, dikoTokenAddress, xusdTokenAddress, dikoXusdPoolAddress, 100);
-    result.expectOk().expectList()[0].expectUint(1000);
-    result.expectOk().expectList()[1].expectUint(200);
+    result.expectOk().expectList()[0].expectUint(1000000000);
+    result.expectOk().expectList()[1].expectUint(200000000);
 
     // Balances again at 0
     call = await swap.getBalances(dikoTokenAddress, xusdTokenAddress);

--- a/clarity/tests/arkadiko-swap-v1-1_test.ts
+++ b/clarity/tests/arkadiko-swap-v1-1_test.ts
@@ -4,7 +4,7 @@ import {
   Clarinet,
   Tx,
   types,
-} from "https://deno.land/x/clarinet@v0.10.0/index.ts";
+} from "https://deno.land/x/clarinet@v0.13.0/index.ts";
 
 import { 
   Swap,

--- a/clarity/tests/arkadiko-vault-rewards-v1-1_test.ts
+++ b/clarity/tests/arkadiko-vault-rewards-v1-1_test.ts
@@ -4,7 +4,7 @@ import {
   Clarinet,
   Tx,
   types,
-} from "https://deno.land/x/clarinet@v0.10.0/index.ts";
+} from "https://deno.land/x/clarinet@v0.13.0/index.ts";
 
 Clarinet.test({
   name: "vault-rewards: vault DIKO rewards",

--- a/clarity/tests/models/arkadiko-tests-swap.ts
+++ b/clarity/tests/models/arkadiko-tests-swap.ts
@@ -4,7 +4,7 @@ import {
   Clarinet,
   Tx,
   types,
-} from "https://deno.land/x/clarinet@v0.10.0/index.ts";
+} from "https://deno.land/x/clarinet@v0.13.0/index.ts";
 
 
 // ---------------------------------------------------------

--- a/clarity/tests/models/arkadiko-tests-tokens.ts
+++ b/clarity/tests/models/arkadiko-tests-tokens.ts
@@ -4,7 +4,7 @@ import {
   Clarinet,
   Tx,
   types,
-} from "https://deno.land/x/clarinet@v0.10.0/index.ts";
+} from "https://deno.land/x/clarinet@v0.13.0/index.ts";
 
 
 // ---------------------------------------------------------

--- a/clarity/tests/models/arkadiko-tests-vaults.ts
+++ b/clarity/tests/models/arkadiko-tests-vaults.ts
@@ -4,7 +4,7 @@ import {
   Clarinet,
   Tx,
   types,
-} from "https://deno.land/x/clarinet@v0.10.0/index.ts";
+} from "https://deno.land/x/clarinet@v0.13.0/index.ts";
 
 
 // ---------------------------------------------------------

--- a/clarity/tests/xusd-token_test.ts
+++ b/clarity/tests/xusd-token_test.ts
@@ -3,7 +3,7 @@ import {
   Chain,
   Clarinet,
   types,
-} from "https://deno.land/x/clarinet@v0.10.0/index.ts";
+} from "https://deno.land/x/clarinet@v0.13.0/index.ts";
 
 Clarinet.test({
   name: "xusd-token: returns the correct name of the xUSD Token",


### PR DESCRIPTION
There was an issue in the way the `expectUint` was written, that was fixed with clarinet v0.13.0.
The following behavior would have been observed in prior versions:

```
"u100".expectUint(1); // pass
"u100".expectUint(10); // pass
"u100".expectUint(100); // pass
"u100".expectUint(1000); // fail
```

This PR is updating the version being imported, and fixing the broken expectations (which looks like broken tests to me, vs broken contracts).
