### PR TITLE
fix: add stxAddress to all contract calls to sign from the correct address

### DIFF
--- a/web/components/add-swap-liquidity.tsx
+++ b/web/components/add-swap-liquidity.tsx
@@ -91,6 +91,7 @@ export const AddSwapLiquidity: React.FC = ({ match }) => {
     await doContractCall({
       network,
       contractAddress,
+      stxAddress,
       contractName: 'arkadiko-swap-v1-1',
       functionName: 'add-to-position',
       functionArgs: [

--- a/web/components/auction-group.tsx
+++ b/web/components/auction-group.tsx
@@ -6,6 +6,7 @@ import { stacksNetwork as network } from '@common/utils';
 import { useConnect } from '@stacks/connect-react';
 import { AppContext } from '@common/context';
 import { websocketTxUpdater } from '@common/websocket-tx-updater';
+import { useSTXAddress } from '@common/use-stx-address';
 
 export interface AuctionProps {
   id: string;
@@ -24,6 +25,7 @@ export const AuctionGroup: React.FC<AuctionProps[]> = ({ auctions }) => {
   const [bidLotId, setBidLotId] = useState(0);
   const [preferredBid, setPreferredBid] = useState(0);
   const contractAddress = process.env.REACT_APP_CONTRACT_ADDRESS || '';
+  const stxAddress = useSTXAddress();
   const [state, setState] = useContext(AppContext);
   websocketTxUpdater();
 
@@ -56,6 +58,7 @@ export const AuctionGroup: React.FC<AuctionProps[]> = ({ auctions }) => {
     await doContractCall({
       network,
       contractAddress,
+      stxAddress,
       contractName: 'arkadiko-auction-engine-v1-1',
       functionName: 'bid',
       functionArgs: [

--- a/web/components/auctions.tsx
+++ b/web/components/auctions.tsx
@@ -145,6 +145,7 @@ export const Auctions: React.FC = () => {
     await doContractCall({
       network,
       contractAddress,
+      stxAddress,
       contractName: 'arkadiko-freddie-v1-1',
       functionName: 'redeem-stx',
       functionArgs: [

--- a/web/components/create-vault-transact.tsx
+++ b/web/components/create-vault-transact.tsx
@@ -49,6 +49,7 @@ export const CreateVaultTransact = ({ coinAmounts }) => {
     await doContractCall({
       network,
       contractAddress,
+      stxAddress: address,
       contractName: 'arkadiko-freddie-v1-1',
       functionName: 'collateralize-and-mint',
       functionArgs: args,

--- a/web/components/lot.tsx
+++ b/web/components/lot.tsx
@@ -1,16 +1,17 @@
-import React, { useContext, useEffect } from 'react';
+import React, { useContext } from 'react';
 import { LotProps } from './lot-group';
 import { contractPrincipalCV, uintCV } from '@stacks/transactions';
 import { useConnect } from '@stacks/connect-react';
 import { stacksNetwork as network } from '@common/utils';
 import { resolveReserveName, tokenTraits } from '@common/vault-utils';
-import { TxStatus } from '@components/tx-status';
 import { websocketTxUpdater } from '@common/websocket-tx-updater';
 import { AppContext } from '@common/context';
+import { useSTXAddress } from '@common/use-stx-address';
 
 export const Lot: React.FC<LotProps> = ({ id, lotId, collateralAmount, collateralToken, xusd }) => {
   const { doContractCall } = useConnect();
   const contractAddress = process.env.REACT_APP_CONTRACT_ADDRESS || '';
+  const stxAddress = useSTXAddress();
   const [_, setState] = useContext(AppContext);
   websocketTxUpdater();
 
@@ -20,6 +21,7 @@ export const Lot: React.FC<LotProps> = ({ id, lotId, collateralAmount, collatera
     await doContractCall({
       network,
       contractAddress,
+      stxAddress,
       contractName: 'arkadiko-auction-engine-v1-1',
       functionName: 'redeem-lot-collateral',
       functionArgs: [

--- a/web/components/manage-vault.tsx
+++ b/web/components/manage-vault.tsx
@@ -170,6 +170,7 @@ export const ManageVault = ({ match }) => {
     await doContractCall({
       network,
       contractAddress,
+      stxAddress: senderAddress,
       contractName: 'arkadiko-freddie-v1-1',
       functionName: 'pay-stability-fee',
       functionArgs: [
@@ -191,6 +192,7 @@ export const ManageVault = ({ match }) => {
     await doContractCall({
       network,
       contractAddress,
+      stxAddress: senderAddress,
       contractName: "arkadiko-freddie-v1-1",
       functionName: 'burn',
       functionArgs: [
@@ -220,6 +222,7 @@ export const ManageVault = ({ match }) => {
     await doContractCall({
       network,
       contractAddress,
+      stxAddress: senderAddress,
       contractName: "arkadiko-freddie-v1-1",
       functionName: 'burn',
       functionArgs: [
@@ -242,6 +245,7 @@ export const ManageVault = ({ match }) => {
     await doContractCall({
       network,
       contractAddress,
+      stxAddress: senderAddress,
       contractName: "arkadiko-vault-rewards-v1-1",
       functionName: "claim-pending-rewards",
       functionArgs: [],
@@ -285,6 +289,7 @@ export const ManageVault = ({ match }) => {
     await doContractCall({
       network,
       contractAddress,
+      stxAddress: senderAddress,
       contractName: "arkadiko-freddie-v1-1",
       functionName: 'deposit',
       functionArgs: [
@@ -346,6 +351,7 @@ export const ManageVault = ({ match }) => {
     await doContractCall({
       network,
       contractAddress,
+      stxAddress: senderAddress,
       contractName: "arkadiko-freddie-v1-1",
       functionName: 'mint',
       functionArgs: [
@@ -368,6 +374,7 @@ export const ManageVault = ({ match }) => {
     await doContractCall({
       network,
       contractAddress,
+      stxAddress: senderAddress,
       contractName: "arkadiko-freddie-v1-1",
       functionName: 'toggle-stacking',
       functionArgs: [uintCV(match.params.id)],
@@ -383,6 +390,7 @@ export const ManageVault = ({ match }) => {
     await doContractCall({
       network,
       contractAddress,
+      stxAddress: senderAddress,
       contractName: "arkadiko-freddie-v1-1",
       functionName: 'stack-collateral',
       functionArgs: [uintCV(match.params.id)],
@@ -403,6 +411,7 @@ export const ManageVault = ({ match }) => {
     await doContractCall({
       network,
       contractAddress,
+      stxAddress: senderAddress,
       contractName: "arkadiko-freddie-v1-1",
       functionName: 'withdraw',
       functionArgs: [
@@ -425,6 +434,7 @@ export const ManageVault = ({ match }) => {
     await doContractCall({
       network,
       contractAddress,
+      stxAddress: senderAddress,
       contractName: 'arkadiko-liquidator-v1-1',
       functionName: 'notify-risky-vault',
       functionArgs: [

--- a/web/components/mint.tsx
+++ b/web/components/mint.tsx
@@ -145,6 +145,7 @@ export const Mint = () => {
     await doContractCall({
       network,
       contractAddress,
+      stxAddress: address,
       contractName: 'arkadiko-dao',
       functionName: 'request-diko-tokens',
       functionArgs: [
@@ -162,6 +163,7 @@ export const Mint = () => {
     await doContractCall({
       network,
       contractAddress,
+      stxAddress: address,
       contractName: 'arkadiko-freddie-v1-1',
       functionName: 'redeem-xusd',
       functionArgs: [

--- a/web/components/remove-swap-liquidity.tsx
+++ b/web/components/remove-swap-liquidity.tsx
@@ -91,6 +91,7 @@ export const RemoveSwapLiquidity: React.FC = ({ match }) => {
     await doContractCall({
       network,
       contractAddress,
+      stxAddress,
       contractName: 'arkadiko-swap-v1-1',
       functionName: 'add-to-position',
       functionArgs: [

--- a/web/components/stake.tsx
+++ b/web/components/stake.tsx
@@ -127,6 +127,7 @@ export const Stake = () => {
     await doContractCall({
       network,
       contractAddress,
+      stxAddress,
       contractName: 'arkadiko-stake-registry-v1-1',
       functionName: 'stake',
       functionArgs: [
@@ -148,6 +149,7 @@ export const Stake = () => {
     await doContractCall({
       network,
       contractAddress,
+      stxAddress,
       contractName: 'arkadiko-stake-registry-v1-1',
       functionName: 'claim-pending-rewards',
       functionArgs: [
@@ -165,6 +167,7 @@ export const Stake = () => {
     await doContractCall({
       network,
       contractAddress,
+      stxAddress,
       contractName: 'arkadiko-stake-registry-v1-1',
       functionName: 'unstake',
       functionArgs: [

--- a/web/components/swap.tsx
+++ b/web/components/swap.tsx
@@ -212,6 +212,7 @@ export const Swap: React.FC = () => {
     await doContractCall({
       network,
       contractAddress,
+      stxAddress,
       contractName: 'arkadiko-swap-v1-1',
       functionName: contractName,
       functionArgs: [

--- a/web/components/vault.tsx
+++ b/web/components/vault.tsx
@@ -9,6 +9,7 @@ import { uintCV, contractPrincipalCV, callReadOnlyFunction, cvToJSON } from '@st
 import { resolveReserveName } from '@common/vault-utils';
 import { tokenTraits } from '@common/vault-utils';
 import { websocketTxUpdater } from '@common/websocket-tx-updater';
+import { useSTXAddress } from '@common/use-stx-address';
 
 export interface VaultProps {
   id: string;
@@ -44,6 +45,7 @@ export const Vault: React.FC<VaultProps> = ({
 }) => {
   const { doContractCall } = useConnect();
   const contractAddress = process.env.REACT_APP_CONTRACT_ADDRESS || '';
+  const stxAddress = useSTXAddress();
   const [stabilityFee, setStabilityFee] = useState(0);
   const [_, setState] = useContext(AppContext);
   websocketTxUpdater();
@@ -90,6 +92,7 @@ export const Vault: React.FC<VaultProps> = ({
     await doContractCall({
       network,
       contractAddress,
+      stxAddress,
       contractName: 'arkadiko-freddie-v1-1',
       functionName: 'withdraw-leftover-collateral',
       functionArgs: [

--- a/web/components/view-proposal.tsx
+++ b/web/components/view-proposal.tsx
@@ -59,6 +59,7 @@ export const ViewProposal = ({ match }) => {
     await doContractCall({
       network,
       contractAddress,
+      stxAddress,
       contractName: 'arkadiko-governance-v1-1',
       functionName: 'vote-for',
       functionArgs: [
@@ -77,6 +78,7 @@ export const ViewProposal = ({ match }) => {
     await doContractCall({
       network,
       contractAddress,
+      stxAddress,
       contractName: 'arkadiko-governance-v1-1',
       functionName: 'vote-against',
       functionArgs: [


### PR DESCRIPTION
Fixes a small bug where you can have multiple accounts on one wallet and sometimes it wouldn't pick the correct address to sign.