### PR TITLE
fix: calculate get-total-staked as total amount staked, not just for user

### DIFF
--- a/clarity/contracts/arkadiko-stake-pool-diko-v1-1.clar
+++ b/clarity/contracts/arkadiko-stake-pool-diko-v1-1.clar
@@ -60,16 +60,8 @@
     ;; Total DIKO
     (total-diko-supply (+ diko-supply rewards-to-add))
 
-    ;; Total stDIKO supply
-    (calculated-stdiko-supply
-      (if (is-eq u0 stdiko-supply)
-        (unwrap-panic (contract-call? .stdiko-token get-total-supply))
-        stdiko-supply
-      )
-    )
-
     ;; User stDIKO percentage
-    (stdiko-percentage (/ (* amount u1000000) calculated-stdiko-supply))
+    (stdiko-percentage (/ (* amount u1000000) stdiko-supply))
 
     ;; Amount of DIKO the user will receive
     (diko-to-receive (/ (* stdiko-percentage total-diko-supply) u1000000))
@@ -135,7 +127,7 @@
 
     (let (
       ;; Amount of DIKO the user will receive
-      (diko-to-receive (unwrap-panic (diko-for-stdiko registry-trait amount u0)))
+      (diko-to-receive (unwrap-panic (diko-for-stdiko registry-trait amount (unwrap-panic (contract-call? .stdiko-token get-total-supply)))))
     )
       ;; Burn stDIKO 
       (try! (contract-call? .arkadiko-dao burn-token .stdiko-token amount staker))

--- a/clarity/contracts/arkadiko-stake-pool-diko-v1-1.clar
+++ b/clarity/contracts/arkadiko-stake-pool-diko-v1-1.clar
@@ -67,7 +67,21 @@
   )
 )
 
-;; Get total amount of DIKO in pool for given staker
+;; Get total amount of DIKO in pool for staker
+(define-read-only (get-stake-of (staker principal))
+  (let (
+    ;; Sender stDIKO balance
+    (stdiko-balance (unwrap-panic (contract-call? .stdiko-token get-balance tx-sender)))
+  )
+    (if (> stdiko-balance u0)
+      ;; Amount of DIKO the user would receive when unstaking
+      (diko-for-stdiko stdiko-balance)
+      u0
+    )
+  )
+)
+
+;; Get total amount of DIKO in pool
 (define-read-only (get-total-staked)
   (unwrap-panic (contract-call? .arkadiko-token get-balance (as-contract tx-sender)))
 )

--- a/clarity/contracts/arkadiko-stake-pool-diko-v1-1.clar
+++ b/clarity/contracts/arkadiko-stake-pool-diko-v1-1.clar
@@ -69,13 +69,7 @@
 
 ;; Get total amount of DIKO in pool for given staker
 (define-read-only (get-total-staked)
-  (let (
-    ;; Sender stDIKO balance
-    (stdiko-balance (unwrap-panic (contract-call? .stdiko-token get-balance tx-sender)))
-  )
-    ;; Amount of DIKO the user would receive when unstaking
-    (diko-for-stdiko stdiko-balance)
-  )
+  (unwrap-panic (contract-call? .arkadiko-token get-balance (as-contract tx-sender)))
 )
 
 ;; Stake tokens (provide amount of DIKO)

--- a/web/components/stake.tsx
+++ b/web/components/stake.tsx
@@ -52,14 +52,17 @@ export const Stake = () => {
         contractAddress,
         contractName: "arkadiko-stake-pool-diko-v1-1",
         functionName: "get-stake-of",
-        functionArgs: [standardPrincipalCV(stxAddress || '')],
+        functionArgs: [
+          contractPrincipalCV(contractAddress, 'arkadiko-stake-registry-v1-1'),
+          standardPrincipalCV(stxAddress || '')
+        ],
         senderAddress: stxAddress || '',
         network: network,
       });
-      let dikoStaked = cvToJSON(userStakedCall).value;
+      let dikoStaked = cvToJSON(userStakedCall).value.value;
       setStakedAmount(dikoStaked);
 
-      const dikoPerYear = 23500000; // TODO: hardcoded 25mio for first year. 144 * 365 * (rewardsPerBlock) / 1000000;
+      const dikoPerYear = 2350000; // TODO: hardcoded 23.5mio*10% for first year. 144 * 365 * (rewardsPerBlock) / 1000000;
       if (dikoStaked > 0) {
         dikoStaked = dikoStaked / 1000000;
         const rewardPercentage = (dikoStaked / totalStaked);

--- a/web/components/stake.tsx
+++ b/web/components/stake.tsx
@@ -48,13 +48,23 @@ export const Stake = () => {
       });
       let totalStaked = cvToJSON(totalStakedCall).value / 1000000;
 
+      const stDikoSupplyCall = await callReadOnlyFunction({
+        contractAddress,
+        contractName: "stdiko-token",
+        functionName: "get-total-supply",
+        functionArgs: [],
+        senderAddress: stxAddress || '',
+        network: network,
+      });
+      const stDikoSupply = cvToJSON(stDikoSupplyCall).value.value;
       const userStakedCall = await callReadOnlyFunction({
         contractAddress,
         contractName: "arkadiko-stake-pool-diko-v1-1",
         functionName: "get-stake-of",
         functionArgs: [
           contractPrincipalCV(contractAddress, 'arkadiko-stake-registry-v1-1'),
-          standardPrincipalCV(stxAddress || '')
+          standardPrincipalCV(stxAddress || ''),
+          uintCV(stDikoSupply)
         ],
         senderAddress: stxAddress || '',
         network: network,

--- a/web/components/stake.tsx
+++ b/web/components/stake.tsx
@@ -7,7 +7,7 @@ import { Container } from './home';
 import { stacksNetwork as network } from '@common/utils';
 import {
   callReadOnlyFunction, contractPrincipalCV, uintCV, cvToJSON,
-  createAssetInfo, FungibleConditionCode,
+  createAssetInfo, FungibleConditionCode, standardPrincipalCV,
   makeStandardFungiblePostCondition
  } from '@stacks/transactions';
 import { useSTXAddress } from '@common/use-stx-address';
@@ -47,15 +47,25 @@ export const Stake = () => {
         network: network,
       });
       let totalStaked = cvToJSON(totalStakedCall).value / 1000000;
-      let dikoStaked = state.balance['stdiko'];
+
+      const userStakedCall = await callReadOnlyFunction({
+        contractAddress,
+        contractName: "arkadiko-stake-pool-diko-v1-1",
+        functionName: "get-stake-of",
+        functionArgs: [standardPrincipalCV(stxAddress || '')],
+        senderAddress: stxAddress || '',
+        network: network,
+      });
+      let dikoStaked = cvToJSON(userStakedCall).value;
       setStakedAmount(dikoStaked);
 
       const dikoPerYear = 23500000; // TODO: hardcoded 25mio for first year. 144 * 365 * (rewardsPerBlock) / 1000000;
       if (dikoStaked > 0) {
+        dikoStaked = dikoStaked / 1000000;
         const rewardPercentage = (dikoStaked / totalStaked);
         setApy(((dikoPerYear / dikoStaked) * rewardPercentage * 100).toFixed(0));
       } else {
-        let dikoStaked = state.balance['diko'] / 1000000;
+        dikoStaked = state.balance['diko'] / 1000000;
         if (totalStaked === 0) { totalStaked = dikoStaked };
         const rewardPercentage = (dikoStaked / totalStaked);
         setApy(((dikoPerYear / dikoStaked) * rewardPercentage * 100).toFixed(0));


### PR DESCRIPTION
@nieldeckx I think you implemented this for the user, but that is not in line with how the other pool contracts calculate the `get-total-staked` amount? Also it crashes in the front-end now..

Can you elaborate if this is correct or not?