### PR TITLE
fix: mint new DIKO when bad debt needs to be covered by a debt auction

### DIFF
--- a/clarity/contracts/arkadiko-auction-engine-v1-1.clar
+++ b/clarity/contracts/arkadiko-auction-engine-v1-1.clar
@@ -442,7 +442,7 @@
     (if (is-eq (get auction-type auction) "debt")
       ;; request "collateral-amount" gov tokens from the DAO
       (begin
-        (try! (contract-call? .arkadiko-dao request-diko-tokens ft (get collateral-amount auction)))
+        (try! (contract-call? .arkadiko-dao request-diko-tokens (get collateral-amount auction)))
         (try! (contract-call? vault-manager redeem-auction-collateral ft token-string reserve (get collateral-amount last-bid) tx-sender))
       )
       (try! (contract-call? vault-manager redeem-auction-collateral ft token-string reserve (get collateral-amount last-bid) tx-sender))

--- a/clarity/contracts/arkadiko-dao.clar
+++ b/clarity/contracts/arkadiko-dao.clar
@@ -148,9 +148,13 @@
 
 ;; This method is called by the auction engine when more bad debt needs to be burned
 ;; but the vault collateral is not sufficient
-;; As a result, this method requests DIKO from the DAO ("foundation reserves")
-(define-public (request-diko-tokens (ft <ft-trait>) (collateral-amount uint))
-  (contract-call? ft transfer collateral-amount (var-get dao-owner) (as-contract (unwrap-panic (get-qualified-name-by-name "sip10-reserve"))) none)
+;; As a result, additional DIKO will be minted to cover bad debt
+(define-public (request-diko-tokens (collateral-amount uint))
+  (begin
+    (asserts! (is-eq (unwrap-panic (get-qualified-name-by-name "auction-engine")) contract-caller) ERR-NOT-AUTHORIZED)
+
+    (contract-call? .arkadiko-token mint-for-dao collateral-amount (as-contract (unwrap-panic (get-qualified-name-by-name "sip10-reserve"))))
+  )
 )
 
 


### PR DESCRIPTION
When bad debt had to be covered and STX collateral was not sufficient, we would previously take this from the foundation reserve.

That resulted in a systemic risk where tokens from the foundation could be drained. This is now changed and we mint new DIKO tokens.