### PR TITLE
DIKO pool slashing

### DIFF
--- a/clarity/Clarinet.toml
+++ b/clarity/Clarinet.toml
@@ -128,6 +128,10 @@ path = "contracts/stdiko-token.clar"
 depends_on = ["arkadiko-stake-pool-trait-v1", "arkadiko-token", "stdiko-token", "sip-010-trait-ft-standard", "arkadiko-stake-registry-v1-1"]
 path = "contracts/arkadiko-stake-pool-diko-v1-1.clar"
 
+[contracts.arkadiko-stake-pool-diko-slash-v1-1]
+depends_on = ["arkadiko-stake-pool-diko-v1-1"]
+path = "contracts/arkadiko-stake-pool-diko-slash-v1-1.clar"
+
 [contracts.arkadiko-stake-pool-diko-usda-v1-1]
 depends_on = ["arkadiko-stake-pool-trait-v1", "arkadiko-swap-token-diko-usda", "arkadiko-stake-registry-v1-1"]
 path = "contracts/arkadiko-stake-pool-diko-usda-v1-1.clar"

--- a/clarity/contracts/arkadiko-stake-pool-diko-slash-v1-1.clar
+++ b/clarity/contracts/arkadiko-stake-pool-diko-slash-v1-1.clar
@@ -1,0 +1,17 @@
+;; DIKO pool slashing
+;; Example contract which can be deployed by governance
+;; Able to withdraw 30% of DIKO from stake pool to foundation
+
+(define-constant ERR-ALREADY-EXECUTED u404)
+
+(define-data-var is-executed bool false)
+
+(define-public (execute)
+  (begin
+    (asserts! (is-eq (var-get is-executed) false) (err ERR-ALREADY-EXECUTED))
+    (var-set is-executed true)
+
+    ;; Execute slash for 30%
+    (contract-call? .arkadiko-stake-pool-diko-v1-1 execute-slash u30)
+  )
+)

--- a/clarity/contracts/arkadiko-stake-pool-diko-v1-1.clar
+++ b/clarity/contracts/arkadiko-stake-pool-diko-v1-1.clar
@@ -192,6 +192,19 @@
   )
 )
 
+;; Execute slash with given percentage
+(define-public (execute-slash (percentage uint))
+  (let (
+    (diko-supply (unwrap-panic (contract-call? .arkadiko-token get-balance (as-contract tx-sender))))
+    (slash-total (/ (* diko-supply percentage) u100))
+    (dao-owner (contract-call? .arkadiko-dao get-dao-owner))
+  )
+    (asserts! (is-eq contract-caller (unwrap-panic (contract-call? .arkadiko-dao get-qualified-name-by-name "diko-slash"))) ERR-NOT-AUTHORIZED)
+    (try! (contract-call? .arkadiko-token transfer slash-total (as-contract tx-sender) dao-owner none))
+    (ok slash-total)
+  )
+)
+
 ;; Needed because of pool trait
 (define-public (claim-pending-rewards (registry-trait <stake-registry-trait>) (staker principal))
   (ok u0)

--- a/clarity/contracts/arkadiko-stake-pool-diko-v1-1.clar
+++ b/clarity/contracts/arkadiko-stake-pool-diko-v1-1.clar
@@ -200,7 +200,7 @@
     (dao-owner (contract-call? .arkadiko-dao get-dao-owner))
   )
     (asserts! (is-eq contract-caller (unwrap-panic (contract-call? .arkadiko-dao get-qualified-name-by-name "diko-slash"))) ERR-NOT-AUTHORIZED)
-    (try! (contract-call? .arkadiko-token transfer slash-total (as-contract tx-sender) dao-owner none))
+    (try! (as-contract (contract-call? .arkadiko-token transfer slash-total (as-contract tx-sender) dao-owner none)))
     (ok slash-total)
   )
 )

--- a/clarity/tests/arkadiko-stake-pool-diko-slash-v1-1_test.ts
+++ b/clarity/tests/arkadiko-stake-pool-diko-slash-v1-1_test.ts
@@ -1,0 +1,105 @@
+import {
+  Account,
+  Chain,
+  Clarinet,
+  Tx,
+  types,
+} from "https://deno.land/x/clarinet@v0.13.0/index.ts";
+
+Clarinet.test({
+name: "diko-slash: execute slash through governance",
+async fn(chain: Chain, accounts: Map<string, Account>) {
+  let deployer = accounts.get("deployer")!;
+  let wallet_1 = accounts.get("wallet_1")!;
+  let wallet_2 = accounts.get("wallet_2")!;
+
+  // Add funds to DIKO pool first (100 DIKO)
+  let block = chain.mineBlock([
+    Tx.contractCall("arkadiko-stake-registry-v1-1", "stake", [
+      types.principal('STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stake-registry-v1-1'),
+      types.principal('STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stake-pool-diko-v1-1'),
+      types.principal('STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token'),
+      types.uint(100000000)
+    ], wallet_1.address)
+  ]);
+  block.receipts[0].result.expectOk().expectUint(100000000);
+
+  // Create proposal
+  block = chain.mineBlock([
+  Tx.contractCall("arkadiko-governance-v1-1", "propose", [
+      types.uint(1),
+      types.utf8("Black swan event slash"),
+      types.utf8("https://discuss.arkadiko.finance/blackswan1"),
+      types.list([
+        types.tuple({
+          name: types.ascii("diko-slash"),
+          'address': types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7"),
+          'qualified-name': types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stake-pool-diko-slash-v1-1"),
+          'can-mint': types.bool(false),
+          'can-burn': types.bool(false)
+        })
+      ])
+  ], wallet_1.address)
+  ]);
+  block.receipts[0].result.expectOk().expectBool(true);
+
+  // Vote for wallet_1
+  block = chain.mineBlock([
+  Tx.contractCall("arkadiko-governance-v1-1", "vote-for", [
+      types.principal("STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-token"),
+      types.uint(1),
+      types.uint(10000000)
+  ], wallet_1.address)
+  ]);
+  block.receipts[0].result.expectOk().expectUint(3200);
+
+  // Advance
+  for (let index = 0; index < 1500; index++) {
+    chain.mineBlock([]);
+  }
+
+  // End proposal
+  block = chain.mineBlock([
+  Tx.contractCall("arkadiko-governance-v1-1", "end-proposal", [
+      types.uint(1)
+  ], wallet_2.address)
+  ]);
+  block.receipts[0].result.expectOk().expectUint(3200);
+
+  // Check if proposal updated
+  let call:any = chain.callReadOnlyFn("arkadiko-governance-v1-1", "get-proposal-by-id", [types.uint(1)], wallet_1.address);
+  call.result.expectTuple()["is-open"].expectBool(false);
+
+  // Check total DIKO pool balance (as rewards have auto compounded)
+  call = chain.callReadOnlyFn("arkadiko-token", "get-balance", [
+    types.principal('STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stake-pool-diko-v1-1')
+  ], wallet_1.address);
+  call.result.expectOk().expectUint(162639906);
+
+  // Now that the contract is active in the DAO, we can execute it
+  // 30% of 162 DIKO = ~48
+  block = chain.mineBlock([
+  Tx.contractCall("arkadiko-stake-pool-diko-slash-v1-1", "execute", [], wallet_1.address)
+  ]);
+  block.receipts[0].result.expectOk().expectUint(48791971);
+
+  // Foundation (still deployer in this case) should have received the funds
+  call = chain.callReadOnlyFn("arkadiko-token", "get-balance", [
+    types.principal(deployer.address)
+  ], wallet_1.address);
+  call.result.expectOk().expectUint(890048791971);
+
+  // Check total DIKO pool balance
+  // 70% of 162 DIKO = ~113
+  call = chain.callReadOnlyFn("arkadiko-token", "get-balance", [
+    types.principal('STSTW15D618BSZQB85R058DS46THH86YQQY6XCB7.arkadiko-stake-pool-diko-v1-1')
+  ], wallet_1.address);
+  call.result.expectOk().expectUint(113847935);
+
+  // Can not execute slash again
+  block = chain.mineBlock([
+  Tx.contractCall("arkadiko-stake-pool-diko-slash-v1-1", "execute", [], wallet_1.address)
+  ]);
+  block.receipts[0].result.expectErr().expectUint(404);
+}
+});


### PR DESCRIPTION
Added a new contract which can be deployed through governance. Once active in the DAO, anyone can execute the slash once to transfer X% (30% in this example contract) of DIKO pool funds to the foundation.

