### PR TITLE
Fixed voting with stDIKO

### DIFF
--- a/clarity/Clarinet.toml
+++ b/clarity/Clarinet.toml
@@ -15,7 +15,7 @@ depends_on = ["arkadiko-token", "arkadiko-collateral-types-v1-1", "arkadiko-vaul
 path = "contracts/arkadiko-dao.clar"
 
 [contracts.arkadiko-governance-v1-1]
-depends_on = ["arkadiko-token", "sip-010-trait-ft-standard"]
+depends_on = ["arkadiko-token", "sip-010-trait-ft-standard", "arkadiko-stake-pool-diko-trait-v1"]
 path = "contracts/arkadiko-governance-v1-1.clar"
 
 [contracts.arkadiko-token]
@@ -165,8 +165,12 @@ path = "contracts/arkadiko-collateral-types-trait-v1.clar"
 depends_on = []
 path = "contracts/stdiko-token.clar"
 
+[contracts.arkadiko-stake-pool-diko-trait-v1]
+depends_on = []
+path = "contracts/arkadiko-stake-pool-diko-trait-v1.clar"
+
 [contracts.arkadiko-stake-pool-diko-v1-1]
-depends_on = ["arkadiko-stake-pool-trait-v1", "arkadiko-token", "stdiko-token", "sip-010-trait-ft-standard", "arkadiko-stake-registry-v1-1"]
+depends_on = ["arkadiko-stake-pool-trait-v1", "arkadiko-stake-pool-diko-trait-v1", "arkadiko-token", "stdiko-token", "sip-010-trait-ft-standard", "arkadiko-stake-registry-v1-1"]
 path = "contracts/arkadiko-stake-pool-diko-v1-1.clar"
 
 [contracts.arkadiko-stake-pool-diko-slash-v1-1]

--- a/clarity/contracts/arkadiko-governance-v1-1.clar
+++ b/clarity/contracts/arkadiko-governance-v1-1.clar
@@ -88,7 +88,7 @@
 (define-read-only (is-token-accepted (token <ft-trait>))
   (let (
     (is-diko (is-eq (contract-of token) .arkadiko-token))
-    (is-stdiko (is-eq (contract-of token) .stake-pool-diko))
+    (is-stdiko (is-eq (contract-of token) .stdiko-token))
   )
     (or is-diko is-stdiko)
   )

--- a/clarity/contracts/arkadiko-stake-pool-diko-trait-v1.clar
+++ b/clarity/contracts/arkadiko-stake-pool-diko-trait-v1.clar
@@ -1,0 +1,9 @@
+;; DIKO pool trait
+(define-trait stake-pool-diko-trait
+  (
+
+    ;; DIKO/stDIKO ratio
+    (diko-stdiko-ratio () (response uint uint))
+
+  )
+)

--- a/clarity/contracts/arkadiko-stake-pool-diko-v1-1.clar
+++ b/clarity/contracts/arkadiko-stake-pool-diko-v1-1.clar
@@ -7,6 +7,7 @@
 ;; When total stake changes, the cumm reward per stake is increased accordingly.
 
 (impl-trait .arkadiko-stake-pool-trait-v1.stake-pool-trait)
+(impl-trait .arkadiko-stake-pool-diko-trait-v1.stake-pool-diko-trait)
 (use-trait ft-trait .sip-010-trait-ft-standard.sip-010-trait)
 (use-trait stake-registry-trait .arkadiko-stake-registry-trait-v1.stake-registry-trait)
 
@@ -93,8 +94,8 @@
     (diko-supply (unwrap-panic (contract-call? .arkadiko-token get-balance (as-contract tx-sender))))
   )
     (if (is-eq stdiko-supply u0)
-      u1000000
-      (/ (* diko-supply u1000000) stdiko-supply)
+      (ok u1000000)
+      (ok (/ (* diko-supply u1000000) stdiko-supply))
     )
   )
 )
@@ -151,7 +152,7 @@
 
     (let (
       ;; DIKO/stDIKO 
-      (diko-stdiko (diko-stdiko-ratio))
+      (diko-stdiko (unwrap-panic (diko-stdiko-ratio)))
 
       ;; Calculate amount of stDIKO to receive
       (stdiko-to-receive (/ (* amount u1000000) diko-stdiko))

--- a/clarity/contracts/arkadiko-stake-pool-trait-v1.clar
+++ b/clarity/contracts/arkadiko-stake-pool-trait-v1.clar
@@ -1,4 +1,3 @@
-;; implements a trait that allows collateral of any token (e.g. stx, bitcoin)
 (use-trait ft-trait .sip-010-trait-ft-standard.sip-010-trait)
 (use-trait stake-registry-trait .arkadiko-stake-registry-trait-v1.stake-registry-trait)
 

--- a/clarity/tests/arkadiko-stake-pool-diko-slash-v1-1_test.ts
+++ b/clarity/tests/arkadiko-stake-pool-diko-slash-v1-1_test.ts
@@ -46,6 +46,7 @@ async fn(chain: Chain, accounts: Map<string, Account>) {
   // Vote for wallet_1
   block = chain.mineBlock([
   Tx.contractCall("arkadiko-governance-v1-1", "vote-for", [
+      types.principal("ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.arkadiko-stake-pool-diko-v1-1"),
       types.principal("ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.arkadiko-token"),
       types.uint(1),
       types.uint(10000000)

--- a/clarity/tests/arkadiko-stake-pool-diko-usda-v1-1_test.ts
+++ b/clarity/tests/arkadiko-stake-pool-diko-usda-v1-1_test.ts
@@ -1025,6 +1025,7 @@ Clarinet.test({
     // Vote for wallet_1
     block = chain.mineBlock([
     Tx.contractCall("arkadiko-governance-v1-1", "vote-for", [
+        types.principal("ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.arkadiko-stake-pool-diko-v1-1"),
         types.principal("ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.arkadiko-token"),
         types.uint(1),
         types.uint(10000000)
@@ -1203,6 +1204,7 @@ Clarinet.test({
     // Vote for wallet_1
     block = chain.mineBlock([
     Tx.contractCall("arkadiko-governance-v1-1", "vote-for", [
+        types.principal("ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.arkadiko-stake-pool-diko-v1-1"),
         types.principal("ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.arkadiko-token"),
         types.uint(1),
         types.uint(10000000)

--- a/clarity/tests/arkadiko-stake-pool-diko-v1-1_tests.ts
+++ b/clarity/tests/arkadiko-stake-pool-diko-v1-1_tests.ts
@@ -46,7 +46,7 @@ async fn(chain: Chain, accounts: Map<string, Account>) {
 
   // At start the ratio is 1
   call = chain.callReadOnlyFn("arkadiko-stake-pool-diko-v1-1", "diko-stdiko-ratio", [], wallet_1.address);
-  call.result.expectUint(1000000);   
+  call.result.expectOk().expectUint(1000000);   
   
   // Staked total
   call = chain.callReadOnlyFn("arkadiko-token", "get-balance", [
@@ -113,7 +113,7 @@ async fn(chain: Chain, accounts: Map<string, Account>) {
 
   // New ratio =  413199530 / 100000000
   call = chain.callReadOnlyFn("arkadiko-stake-pool-diko-v1-1", "diko-stdiko-ratio", [], wallet_1.address);
-  call.result.expectUint(4131995);   
+  call.result.expectOk().expectUint(4131995);   
 
   // Unstake funds fails because cooldown not started
   block = chain.mineBlock([
@@ -196,7 +196,7 @@ async fn(chain: Chain, accounts: Map<string, Account>) {
 
   // 162/100 = 1.62
   call = chain.callReadOnlyFn("arkadiko-stake-pool-diko-v1-1", "diko-stdiko-ratio", [], wallet_1.address);
-  call.result.expectUint(1626399);  
+  call.result.expectOk().expectUint(1626399);  
 
   // Stake - Wallet 2
   // New ratio in next block will be (162 + 62)/100 = 2.24


### PR DESCRIPTION
User was not able to vote with stDIKO. This is fixed.

Users are able to vote with both DIKO and stDIKO. However 1 DIKO is not equal to 1 stDIKO so we need to take this into account when counting votes. Improved voting by converting stDIKO to DIKO at the current rate defined in the stake pool.