### PR TITLE
Fix tooltips

### DIFF
--- a/web/components/app.tsx
+++ b/web/components/app.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Tooltip } from '@blockstack/ui';
+import { ThemeProvider, theme, Tooltip } from '@blockstack/ui';
 import { Connect } from '@stacks/connect-react';
 import { AuthOptions } from '@stacks/connect';
 import { UserSession, AppConfig } from '@stacks/auth';
@@ -162,36 +162,38 @@ export const App: React.FC = () => {
 
   return (
     <Connect authOptions={authOptions}>
-      <AppContext.Provider value={[state, setState]}>
-        <div className="flex flex-col bg-white min-height-screen">
-          <Header signOut={signOut} setShowSidebar={setShowSidebar} />
-          {state.userData ? (
-            <SubHeader />
-          ) : null}
-          <TxStatus />
-          {showSidebar ? (
-            <TxSidebar setShowSidebar={setShowSidebar} />
-          ) : null}
-          <TestnetModal />
+      <ThemeProvider theme={theme}>
+        <AppContext.Provider value={[state, setState]}>
+          <div className="flex flex-col bg-white min-height-screen">
+            <Header signOut={signOut} setShowSidebar={setShowSidebar} />
+            {state.userData ? (
+              <SubHeader />
+            ) : null}
+            <TxStatus />
+            {showSidebar ? (
+              <TxSidebar setShowSidebar={setShowSidebar} />
+            ) : null}
+            <TestnetModal />
 
-          <div className="fixed bottom-0 right-0 flex items-end justify-center px-4 py-6 pointer-events-none sm:p-6 sm:items-start sm:justify-end" style={{zIndex: 99999}}>
-            <Tooltip label={`Got feedback?`}>
-              <div className="w-full max-w-sm overflow-hidden pointer-events-auto">
-                <div className="p-4">
-                  <div className="flex items-start">
-                    <a href="mailto:philip@arkadiko.finance?subject=Feedback on Arkadiko Testnet" className="inline-flex items-center p-2 text-white bg-indigo-600 border border-transparent rounded-full shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
-                      <svg xmlns="http://www.w3.org/2000/svg" className="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
-                        <path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-8-3a1 1 0 00-.867.5 1 1 0 11-1.731-1A3 3 0 0113 8a3.001 3.001 0 01-2 2.83V11a1 1 0 11-2 0v-1a1 1 0 011-1 1 1 0 100-2zm0 8a1 1 0 100-2 1 1 0 000 2z" clipRule="evenodd" />
-                      </svg>
-                    </a>
+            <div className="fixed bottom-0 right-0 flex items-end justify-center px-4 py-6 pointer-events-none sm:p-6 sm:items-start sm:justify-end" style={{zIndex: 99999}}>
+              <Tooltip label={`Got feedback?`}>
+                <div className="w-full max-w-sm overflow-hidden pointer-events-auto">
+                  <div className="p-4">
+                    <div className="flex items-start">
+                      <a href="mailto:philip@arkadiko.finance?subject=Feedback on Arkadiko Testnet" className="inline-flex items-center p-2 text-white bg-indigo-600 border border-transparent rounded-full shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
+                        <svg xmlns="http://www.w3.org/2000/svg" className="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
+                          <path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-8-3a1 1 0 00-.867.5 1 1 0 11-1.731-1A3 3 0 0113 8a3.001 3.001 0 01-2 2.83V11a1 1 0 11-2 0v-1a1 1 0 011-1 1 1 0 100-2zm0 8a1 1 0 100-2 1 1 0 000 2z" clipRule="evenodd" />
+                        </svg>
+                      </a>
+                    </div>
                   </div>
                 </div>
-              </div>
-            </Tooltip>
+              </Tooltip>
+            </div>
+            <Routes />
           </div>
-          <Routes />
-        </div>
-      </AppContext.Provider>
+        </AppContext.Provider>
+      </ThemeProvider>
       <ScrollToTop />
     </Connect>
   );


### PR DESCRIPTION
We need the `theme` and `ThemeProvider` from `@blockstack/ui` for the tooltips to be displayed properly.
I shouldn't have removed them in #173.
I will probably refactor this later anyway in favor of https://atomiks.github.io/tippyjs/