### PR TITLE
Pool small UX improvements

### DIFF
--- a/web/components/add-swap-liquidity.tsx
+++ b/web/components/add-swap-liquidity.tsx
@@ -12,7 +12,7 @@ import { useSTXAddress } from '@common/use-stx-address';
 import { stacksNetwork as network } from '@common/utils';
 import { useConnect } from '@stacks/connect-react';
 import { tokenTraits } from '@common/vault-utils';
-import { InformationCircleIcon, PlusCircleIcon, MinusCircleIcon } from '@heroicons/react/solid';
+import { InformationCircleIcon, PlusCircleIcon, MinusCircleIcon, ArrowLeftIcon } from '@heroicons/react/solid';
 import { CashIcon, PlusIcon } from '@heroicons/react/outline';
 import { TokenSwapList, tokenList } from '@components/token-swap-list';
 import { Tooltip } from '@blockstack/ui';
@@ -286,11 +286,21 @@ export const AddSwapLiquidity: React.FC = ({ match }) => {
       {state.userData ? (
         <Container>
           <main className="relative flex flex-col items-center justify-center flex-1 py-12 pb-8">
+            <p className="w-full max-w-lg">
+              <RouterLink className="" to={`/pool`} exact>
+                <span className="p-1.5 rounded-md inline-flex items-center">
+                  <ArrowLeftIcon className="w-4 h-4 mr-2 text-gray-500 group-hover:text-gray-900" aria-hidden="true" />
+                  <span className="text-gray-600 hover:text-gray-900">
+                    Back to Pool
+                  </span>
+                </span>
+              </RouterLink>
+            </p>
             <div className="relative z-10 w-full max-w-lg bg-white rounded-lg shadow">
               <div className="flex flex-col p-4">
                 <div className="flex justify-between mb-4">
                   <div>
-                    <h2 className="text-lg font-medium leading-6 text-gray-900 font-headings">
+                    <h2 className="text-xl leading-6 text-gray-900 font-headings">
                       Liquidity
                     </h2>
                     <p className="inline-flex items-center mt-1 text-sm text-gray-600">

--- a/web/components/add-swap-liquidity.tsx
+++ b/web/components/add-swap-liquidity.tsx
@@ -291,7 +291,7 @@ export const AddSwapLiquidity: React.FC = ({ match }) => {
                 <span className="p-1.5 rounded-md inline-flex items-center">
                   <ArrowLeftIcon className="w-4 h-4 mr-2 text-gray-500 group-hover:text-gray-900" aria-hidden="true" />
                   <span className="text-gray-600 hover:text-gray-900">
-                    Back to Pool
+                    Back to pool overview
                   </span>
                 </span>
               </RouterLink>

--- a/web/components/pool.tsx
+++ b/web/components/pool.tsx
@@ -54,8 +54,8 @@ export const Pool: React.FC = () => {
               </div>
             </div>
 
-            <div>
-              <h3 className="text-base font-medium leading-6 font-headings">Your liquidity positions</h3>
+            <div className="p-3">
+              <h3 className="text-xl leading-6 font-headings">Your liquidity positions</h3>
               <dl className="mt-6 space-y-6 divide-y divide-gray-200">
                 <PoolPosition
                   key="token1"

--- a/web/components/remove-swap-liquidity.tsx
+++ b/web/components/remove-swap-liquidity.tsx
@@ -197,7 +197,7 @@ export const RemoveSwapLiquidity: React.FC = ({ match }) => {
                 <span className="p-1.5 rounded-md inline-flex items-center">
                   <ArrowLeftIcon className="w-4 h-4 mr-2 text-gray-500 group-hover:text-gray-900" aria-hidden="true" />
                   <span className="text-gray-600 hover:text-gray-900">
-                    Back to Pool
+                    Back to pool overview
                   </span>
                 </span>
               </RouterLink>

--- a/web/components/remove-swap-liquidity.tsx
+++ b/web/components/remove-swap-liquidity.tsx
@@ -11,7 +11,7 @@ import { useSTXAddress } from '@common/use-stx-address';
 import { stacksNetwork as network } from '@common/utils';
 import { useConnect } from '@stacks/connect-react';
 import { tokenTraits } from '@common/vault-utils';
-import { InformationCircleIcon, PlusCircleIcon, MinusCircleIcon } from '@heroicons/react/solid';
+import { InformationCircleIcon, PlusCircleIcon, MinusCircleIcon, ArrowLeftIcon } from '@heroicons/react/solid';
 import { ArrowDownIcon } from '@heroicons/react/outline';
 import { tokenList } from '@components/token-swap-list';
 import { Tooltip } from '@blockstack/ui';
@@ -192,11 +192,21 @@ export const RemoveSwapLiquidity: React.FC = ({ match }) => {
       {state.userData ? (
         <Container>
           <main className="relative flex flex-col items-center justify-center flex-1 py-12 pb-8">
+            <p className="w-full max-w-lg">
+              <RouterLink className="" to={`/pool`} exact>
+                <span className="p-1.5 rounded-md inline-flex items-center">
+                  <ArrowLeftIcon className="w-4 h-4 mr-2 text-gray-500 group-hover:text-gray-900" aria-hidden="true" />
+                  <span className="text-gray-600 hover:text-gray-900">
+                    Back to Pool
+                  </span>
+                </span>
+              </RouterLink>
+            </p>
             <div className="relative z-10 w-full max-w-lg bg-white rounded-lg shadow">
               <div className="flex flex-col p-4">
                 <div className="flex justify-between mb-4">
                   <div>
-                    <h2 className="text-lg font-medium leading-6 text-gray-900 font-headings">
+                    <h2 className="text-xl font-medium leading-6 text-gray-900 font-headings">
                       Liquidity
                     </h2>
                     <p className="inline-flex items-center mt-1 text-sm text-gray-600">


### PR DESCRIPTION
### Added a Back to Pool link to both Add and Remove liquidity pages

![Screen Shot 2021-09-16 at 6 53 26 AM](https://user-images.githubusercontent.com/1909957/133559624-d7ea4c7f-3f30-4860-9a35-42e399671904.png)
![Screen Shot 2021-09-16 at 6 53 09 AM](https://user-images.githubusercontent.com/1909957/133559629-57199aac-c634-415b-99a7-40546a141d6f.png)

### Better padding on Pool container
|Before|After|
|---|---|
|![Screen Shot 2021-09-16 at 6 36 19 AM](https://user-images.githubusercontent.com/1909957/133559632-ac5d2ffb-9f43-4261-b896-686bc61733ad.png)|![Screen Shot 2021-09-16 at 6 36 38 AM](https://user-images.githubusercontent.com/1909957/133559630-1fc37849-f465-4438-ba51-412be1f9062e.png)|

