### PR TITLE
fix: add some margin to burn post condition for paying stability fee

### DIFF
--- a/web/components/manage-vault.tsx
+++ b/web/components/manage-vault.tsx
@@ -197,11 +197,12 @@ export const ManageVault = ({ match }) => {
 
   const callBurn = async () => {
     const token = tokenTraits[vault['collateralToken'].toLowerCase()]['name'];
+    const totalToBurn = Number(usdToBurn) + (2 * (stabilityFee / 1000000));
     const postConditions = [
       makeStandardFungiblePostCondition(
         senderAddress || '',
-        FungibleConditionCode.Equal,
-        uintCV(parseFloat(usdToBurn) * 1000000).value,
+        FungibleConditionCode.LessEqual,
+        uintCV(totalToBurn * 1000000).value,
         createAssetInfo(
           contractAddress,
           'usda-token',


### PR DESCRIPTION
The reason the burn PC was failing was due to the extra payment of stability fees in the burn method. As a result, the PC showed a USDA fee that is too low.