### PR TITLE
Improve list limits [0f-ARK-010]

### DIFF
--- a/clarity/contracts/arkadiko-vault-data-v1-1.clar
+++ b/clarity/contracts/arkadiko-vault-data-v1-1.clar
@@ -177,7 +177,7 @@
       }
     )
     (if (is-none (index-of entries lot-index))
-      (map-set stacking-payout-lots { vault-id: vault-id } { ids: (unwrap-panic (as-max-len? (append entries lot-index) u20)) })
+      (map-set stacking-payout-lots { vault-id: vault-id } { ids: (unwrap-panic (as-max-len? (append entries lot-index) u500)) })
       true
     )
     (ok true)

--- a/clarity/contracts/arkadiko-vault-data-v1-1.clar
+++ b/clarity/contracts/arkadiko-vault-data-v1-1.clar
@@ -25,7 +25,7 @@
   auction-ended: bool,
   leftover-collateral: uint
 })
-(define-map vault-entries { user: principal } { ids: (list 500 uint) })
+(define-map vault-entries { user: principal } { ids: (list 20 uint) })
 (define-map closing-vault
   { user: principal }
   { vault-id: uint }
@@ -130,7 +130,7 @@
   (let ((entries (get ids (get-vault-entries user))))
     (asserts! (is-eq contract-caller (unwrap-panic (contract-call? .arkadiko-dao get-qualified-name-by-name "freddie"))) (err ERR-NOT-AUTHORIZED))
 
-    (map-set vault-entries { user: user } { ids: (unwrap-panic (as-max-len? (append entries vault-id) u500)) })
+    (map-set vault-entries { user: user } { ids: (unwrap-panic (as-max-len? (append entries vault-id) u20)) })
     (ok true)
   )
 )
@@ -177,7 +177,7 @@
       }
     )
     (if (is-none (index-of entries lot-index))
-      (map-set stacking-payout-lots { vault-id: vault-id } { ids: (unwrap-panic (as-max-len? (append entries lot-index) u500)) })
+      (map-set stacking-payout-lots { vault-id: vault-id } { ids: (unwrap-panic (as-max-len? (append entries lot-index) u20)) })
       true
     )
     (ok true)

--- a/clarity/tests/arkadiko-vault-rewards-v1-1_test.ts
+++ b/clarity/tests/arkadiko-vault-rewards-v1-1_test.ts
@@ -255,9 +255,8 @@ Clarinet.test({
       // Advance 1 day
       chain.mineEmptyBlock(144);
 
-      // Need an action to update cumm reward, otherwise "get-pending-rewards" lacks behind
-      let result = vaultManager.createVault(wallet_1, "STX-A", 0.01, 0.000001);
-      result.expectOk().expectUint(1);
+      // Need to increase cumm rewards per collateral
+      vaultRewards.increaseCummulativeRewardPerCollateral();
 
       // Get pending rewards
       let call = vaultRewards.getPendingRewards(deployer);
@@ -267,14 +266,14 @@ Clarinet.test({
 
       switch (index)
       {
-        case 7: call.result.expectOk().expectUintWithDecimals(363052); break; // 363k
-        case 14: call.result.expectOk().expectUintWithDecimals(650622.485); break; // 650k
-        case 21: call.result.expectOk().expectUintWithDecimals(912099.195); break; // 912k
-        case 28: call.result.expectOk().expectUintWithDecimals(1150063.59); break; // 1.15 mio
-        case 35: call.result.expectOk().expectUintWithDecimals(1366573.1); break; // 1.36 mio
-        case 42: call.result.expectOk().expectUintWithDecimals(1510462.73); break; // 1.51 mio
-        case 49: call.result.expectOk().expectUintWithDecimals(1510462.73); break; // 1.51 mio
-        case 56: call.result.expectOk().expectUintWithDecimals(1510462.73); break; // 1.51 mio
+        case 7: call.result.expectOk().expectUintWithDecimals(363054.515); break; // 363k
+        case 14: call.result.expectOk().expectUintWithDecimals(650631.305); break; // 650k
+        case 21: call.result.expectOk().expectUintWithDecimals(912117.4); break; // 912k
+        case 28: call.result.expectOk().expectUintWithDecimals(1150093.67); break; // 1.15 mio
+        case 35: call.result.expectOk().expectUintWithDecimals(1366617.03); break; // 1.36 mio
+        case 42: call.result.expectOk().expectUintWithDecimals(1510517.6); break; // 1.51 mio
+        case 49: call.result.expectOk().expectUintWithDecimals(1510517.6); break; // 1.51 mio
+        case 56: call.result.expectOk().expectUintWithDecimals(1510517.6); break; // 1.51 mio
         default: break;
       }
     }

--- a/clarity/tests/models/arkadiko-tests-vaults.ts
+++ b/clarity/tests/models/arkadiko-tests-vaults.ts
@@ -462,5 +462,12 @@ class VaultRewards {
     return block.receipts[0].result;
   }
 
+  increaseCummulativeRewardPerCollateral() {
+    let block = this.chain.mineBlock([
+      Tx.contractCall("arkadiko-vault-rewards-v1-1", "increase-cumm-reward-per-collateral", [], this.deployer.address)
+    ]);
+    return block.receipts[0].result;
+  }
+
 }
 export { VaultRewards };


### PR DESCRIPTION
Changed:
- vault-entries: 500 -> 20

Others:
- winning-lots: 100
- auction-ids: 1500
- pairs-list: 2000
- stacking-payout-lots: 500
- proposal-ids: 100
- contract-changes: 10

I think they are fine for now. We will need to find a way to have more auctions and proposals but this would require too much refactoring at this point.

