### PR TITLE
Users can deposit into any vault [0f-ARK-004]

### DIFF
--- a/clarity/contracts/arkadiko-freddie-v1-1.clar
+++ b/clarity/contracts/arkadiko-freddie-v1-1.clar
@@ -412,6 +412,7 @@
     )
     (asserts! (is-eq (contract-of coll-type) (unwrap-panic (contract-call? .arkadiko-dao get-qualified-name-by-name "collateral-types"))) (err ERR-NOT-AUTHORIZED))
     (asserts! (is-eq (get is-liquidated vault) false) (err ERR-VAULT-LIQUIDATED))
+    (asserts! (is-eq tx-sender (get owner vault)) (err ERR-NOT-AUTHORIZED))
     (asserts!
       (or
         (is-eq collateral-token "STX")


### PR DESCRIPTION
I saw your comment in the audit ticket. If a user creates a vault with wallet A and wants to deposit funds from wallet B, he can just transfer the funds first. All platforms I have been using work like this. Transfers on Stacks are easy and cheap.

A check on SC is better imo as now you can trust the SC instead of a centralised FE.