### PR TITLE
feat: allow changing token address of collateral type

### DIFF
--- a/clarity/contracts/arkadiko-collateral-types-v1-1.clar
+++ b/clarity/contracts/arkadiko-collateral-types-v1-1.clar
@@ -124,6 +124,17 @@
   )
 )
 
+(define-public (change-token-address (collateral-type (string-ascii 12)) (address principal))
+  (let (
+    (type (unwrap-panic (get-collateral-type-by-name collateral-type)))
+  )
+    (asserts! (is-eq tx-sender OWNER) (err ERR-NOT-AUTHORIZED))
+
+    (map-set collateral-types { name: collateral-type } (merge type { token-address: address }))
+    (ok true)
+  )
+)
+
 (define-private (change-risk-parameter (change (tuple (key (string-ascii 256)) (new-value uint)))
                                        (type (tuple (collateral-to-debt-ratio uint) (liquidation-penalty uint) (liquidation-ratio uint)
                                               (maximum-debt uint) (name (string-ascii 256)) (stability-fee uint) (stability-fee-apy uint) (stability-fee-decimals uint)

--- a/clarity/tests/arkadiko-collateral-types-v1-1_test.ts
+++ b/clarity/tests/arkadiko-collateral-types-v1-1_test.ts
@@ -111,3 +111,20 @@ Clarinet.test({
     vaultCreation.expectErr().expectUint(410);
   }
 });
+
+Clarinet.test({
+  name: "collateral types: change token address",
+  async fn(chain: Chain, accounts: Map<string, Account>) {
+    let deployer = accounts.get("deployer")!;
+    let wallet_1 = accounts.get("wallet_1")!;
+
+    let collateralTypeManager = new CollateralTypeManager(chain, deployer);
+    let result = collateralTypeManager.getTokenAddress('STX-A');
+    result['result'].expectOk().expectPrincipal(deployer.address);
+
+    let res = collateralTypeManager.changeTokenAddress('STX-A', wallet_1.address);
+    res.expectOk();
+    result = collateralTypeManager.getTokenAddress('STX-A');
+    result['result'].expectOk().expectPrincipal(wallet_1.address);
+  }
+});

--- a/clarity/tests/models/arkadiko-tests-collateral-types.ts
+++ b/clarity/tests/models/arkadiko-tests-collateral-types.ts
@@ -117,5 +117,15 @@ class CollateralTypeManager {
     ]);
     return block.receipts[0].result;
   }
+
+  changeTokenAddress(collateralType: string, principal: string) {
+    let block = this.chain.mineBlock([
+      Tx.contractCall("arkadiko-collateral-types-v1-1", "change-token-address", [
+        types.ascii(collateralType),
+        types.principal(principal)
+      ], this.deployer.address)
+    ]);
+    return block.receipts[0].result;
+  }
 }
 export { CollateralTypeManager };


### PR DESCRIPTION
We can already change the risk parameters in the first version at launch.

This will help us change the contract address (i.e. for xBTC if we need to change it for some reason)