### PR TITLE
Fix react warnings for input checkboxes in vault creation

### DIFF
--- a/web/components/create-vault-confirm.tsx
+++ b/web/components/create-vault-confirm.tsx
@@ -180,9 +180,8 @@ export const CreateVaultConfirm = ({ setStep, coinAmounts, setCoinAmounts }) => 
                       <input
                         type="checkbox"
                         className="w-6 h-6 border border-gray-300 rounded-md appearance-none form-tick checked:bg-blue-600 checked:border-transparent focus:outline-none"
-                        defaultChecked={coinAmounts['stack-pox']}
                         checked={coinAmounts['stack-pox']}
-                        onClick={() => togglePox()}
+                        onChange={() => togglePox()}
                       />
                       <span className="text-gray-900">I want my STX tokens stacked to earn yield</span>
                     </label>
@@ -190,9 +189,8 @@ export const CreateVaultConfirm = ({ setStep, coinAmounts, setCoinAmounts }) => 
                       <input
                         type="checkbox"
                         className="w-6 h-6 border border-gray-300 rounded-md appearance-none form-tick checked:bg-blue-600 checked:border-transparent focus:outline-none"
-                        defaultChecked={coinAmounts['auto-payoff']}
                         checked={coinAmounts['auto-payoff']}
-                        onClick={() => toggleAutoPayoff()}
+                        onChange={() => toggleAutoPayoff()}
                       />
                       <span className="text-gray-900">I want my vault loan to be paid off automatically through the earned yield</span>
                     </label>


### PR DESCRIPTION
<img width="1440" alt="Screen Shot 2021-10-11 at 9 13 02 PM" src="https://user-images.githubusercontent.com/1909957/136850611-2931c2b8-0540-4c3d-a3eb-d2d1e93d9a05.png">


@victorcoder, could you have a look as well? Is it the best solution to fix those warnings?