### PR TITLE
fix: mixed up token prices in Remove Liquidity page

### DIFF
--- a/web/components/remove-swap-liquidity.tsx
+++ b/web/components/remove-swap-liquidity.tsx
@@ -381,10 +381,10 @@ export const RemoveSwapLiquidity: React.FC = ({ match }) => {
                     <h4 className="text-xs font-normal text-gray-700 uppercase font-headings">Price</h4>
                     <div className="mt-3 sm:mt-0 space-y-0.5 lg:text-right text-sm text-gray-500">
                       <p>
-                        1 {tokenX.name} = {tokenXPrice} {tokenY.name}
+                        1 {tokenX.name} = {tokenYPrice} {tokenY.name}
                       </p>
                       <p  >
-                        1 {tokenY.name} = {tokenYPrice} {tokenX.name}
+                        1 {tokenY.name} = {tokenXPrice} {tokenX.name}
                       </p>                    
                     </div>
                   </div>


### PR DESCRIPTION
Those are mixed up:

<img src="https://cdn.discordapp.com/attachments/889889513785159720/900758411250118706/unknown.png" alt="">