### PR TITLE
feat: show staked tokens on pool page

### DIFF
--- a/web/components/pool-position.tsx
+++ b/web/components/pool-position.tsx
@@ -186,9 +186,7 @@ export const PoolPosition: React.FC = ({ indexTokenX, indexTokenY }) => {
                     </div>
                   </dt>
                   <dd className="mt-1 text-sm font-semibold text-indigo-900 sm:mt-0 sm:text-right">
-                    {state.balance[tokenPair] > 0 ? (
-                      `${totalShare}%`
-                    ) : `0%` }
+                    {totalShare}%
                   </dd>
                 </div>
                 


### PR DESCRIPTION
Should help users to understand that they need to unstake before being able to remove liquidity.
@Macxim need your help to make this pretty ;) 

<img width="537" alt="Screenshot 2021-10-23 at 20 47 50" src="https://user-images.githubusercontent.com/5592676/138568223-0a9d269f-9792-4d08-9bbf-ab9cabb331ec.png">
