### PR TITLE
tweak: update balances table with more info

### DIFF
--- a/clarity/contracts/arkadiko-stake-pool-diko-v1-1.clar
+++ b/clarity/contracts/arkadiko-stake-pool-diko-v1-1.clar
@@ -1,4 +1,4 @@
-;; @contract DIKO Stake Pool - Stake DIKO to get sDIKO
+;; @contract DIKO Stake Pool - Stake DIKO to get stDIKO
 ;; A fixed amount of rewards per block will be distributed across all stakers, according to their size in the pool
 ;; Rewards will be automatically staked before staking or unstaking. 
 ;; The cumm reward per stake represents the rewards over time, taking into account total staking volume over time

--- a/clarity/contracts/tests/arkadiko-stake-pool-diko-tv1-1.clar
+++ b/clarity/contracts/tests/arkadiko-stake-pool-diko-tv1-1.clar
@@ -1,4 +1,4 @@
-;; Stake Pool - Stake DIKO to get sDIKO
+;; Stake Pool - Stake DIKO to get stDIKO
 ;; 
 ;; A fixed amount of rewards per block will be distributed across all stakers, according to their size in the pool
 ;; Rewards will be automatically staked before staking or unstaking. 

--- a/web/components/balances.tsx
+++ b/web/components/balances.tsx
@@ -1,53 +1,117 @@
 import React from 'react';
-import { Box } from '@blockstack/ui';
+import { Container } from './home';
 import { SmartContractBalance } from './smart-contract-balance';
 
 export const Balances = () => {
   const contractAddress = process.env.REACT_APP_CONTRACT_ADDRESS || '';
   const addresses = [
-    `${contractAddress}.arkadiko-stx-reserve-v1-1`,
-    `${contractAddress}.arkadiko-sip10-reserve-v1-1`,
-    `${contractAddress}.arkadiko-freddie-v1-1`,
-    `${contractAddress}.arkadiko-auction-engine-v1-1`,
-    `${contractAddress}.arkadiko-dao`,
-    `${contractAddress}.arkadiko-governance-v1-1`,
-    `${contractAddress}.arkadiko-stacker-v1-1`,
-    `${contractAddress}.arkadiko-stacker-2-v1-1`,
-    `${contractAddress}.arkadiko-stacker-3-v1-1`,
-    `${contractAddress}.arkadiko-stacker-4-v1-1`,
-    `${contractAddress}.arkadiko-stacker-payer-v1-1`,
-    `${contractAddress}.arkadiko-stake-pool-diko-v1-1`,
-    `${contractAddress}.arkadiko-stake-pool-diko-usda-v1-1`,
-    `${contractAddress}.arkadiko-stake-pool-wstx-usda-v1-1`,
-    `${contractAddress}.arkadiko-swap-v1-1`,
+    {
+      'address': `${contractAddress}.arkadiko-stx-reserve-v1-1`,
+      'name': 'STX Reserve v1',
+      'description': 'Reserve of collateralized STX in Vaults'
+    },
+    {
+      'address': `${contractAddress}.arkadiko-sip10-reserve-v1-1`,
+      'name': 'SIP10 Reserve v1',
+      'description': 'Reserve of all SIP10 collateral types'
+    },
+    {
+      'address': `${contractAddress}.arkadiko-freddie-v1-1`,
+      'name': 'Freddie v1',
+      'description': 'Vault Manager. Freddie is an abstraction layer that interacts with collateral type reserves'
+    },
+    {
+      'address': `${contractAddress}.arkadiko-auction-engine-v1-1`,
+      'name': 'Auction Engine v1',
+      'description': 'Sells off vault collateral to raise USDA'
+    },
+    {
+      'address': `${contractAddress}.arkadiko-dao`,
+      'name': 'DAO',
+      'description': 'Keep contracts used in protocol. Emergency switch to shut down protocol'
+    },
+    {
+      'address': `${contractAddress}.arkadiko-governance-v1-1`,
+      'name': 'Governance v1',
+      'description': 'Can see, vote and submit a new proposal. A proposal will just update the DAO with new contracts'
+    },
+    {
+      'address': `${contractAddress}.arkadiko-stacker-v1-1`,
+      'name': 'Stacker v1',
+      'description': 'Stacker initiates stacking for the STX reserve. Stacks the STX tokens in PoX'
+    },
+    {
+      'address': `${contractAddress}.arkadiko-stacker-2-v1-1`,
+      'name': 'Stacker 2 v1',
+      'description': 'Stacker initiates stacking for the STX reserve. Stacks the STX tokens in PoX'
+    },
+    {
+      'address': `${contractAddress}.arkadiko-stacker-3-v1-1`,
+      'name': 'Stacker 3 v1',
+      'description': 'Stacker initiates stacking for the STX reserve. Stacks the STX tokens in PoX'
+    },
+    {
+      'address': `${contractAddress}.arkadiko-stacker-4-v1-1`,
+      'name': 'Stacker 4 v1',
+      'description': 'Stacker initiates stacking for the STX reserve. Stacks the STX tokens in PoX'
+    },
+    {
+      'address': `${contractAddress}.arkadiko-stacker-payer-v1-1`,
+      'name': 'Stacker Payer v1',
+      'description': 'Pays rewards after PoX cycle is over'
+    },
+    {
+      'address': `${contractAddress}.arkadiko-stake-pool-diko-v1-1`,
+      'name': 'Stake Pool DIKO v1',
+      'description': 'DIKO Stake Pool - Stake DIKO to get stDIKO'
+    },
+    {
+      'address': `${contractAddress}.arkadiko-stake-pool-diko-usda-v1-1`,
+      'name': 'Stake Pool DIKO/USDA v1',
+      'description': 'Stake Pool - Stake DIKO-USDA LP tokens'
+    },
+    {
+      'address': `${contractAddress}.arkadiko-stake-pool-wstx-usda-v1-1`,
+      'name': 'Stake Pool wSTX/USDA v1',
+      'description': 'Stake Pool - Stake wSTX-USDA LP tokens'
+    },
+    {
+      'address': `${contractAddress}.arkadiko-stake-pool-wstx-diko-v1-1`,
+      'name': 'Stake Pool wSTX/DIKO v1',
+      'description': 'Stake Pool - Stake wSTX-DIKO LP tokens'
+    },
+    {
+      'address': `${contractAddress}.arkadiko-swap-v1-1`,
+      'name': 'Swap v1',
+      'description': 'Arkadiko\'s Decentralised Exchange'
+    }
   ]
   let index = -1;
-  const contractBalances = addresses.map((address:string) => {
+  const contractBalances = addresses.map((item) => {
     index += 1;
     return (<SmartContractBalance
       key={index}
-      address={address}
+      address={item.address}
+      description={item.description}
+      name={item.name}
     />);
   });
 
   return (
-    <Box>
-      <main className="relative z-0 flex-1 pb-8 overflow-y-auto">
-        <div className="mt-8">
-          <div className="px-4 mx-auto sm:px-6 lg:px-8">
-
-            <div className="bg-indigo-700">
-              <div className="max-w-2xl px-4 py-5 mx-auto text-center sm:py-5 sm:px-6 lg:px-8">
-                <h2 className="text-3xl font-bold text-white sm:text-4xl font-headings">
-                  <span className="block">Arkadiko Balances</span>
-                </h2>
-                <p className="mt-4 text-lg leading-6 text-indigo-200">
-                  An overview of all Arkadiko smart contracts and their balances
-                </p>
-              </div>
+    <Container>
+      <main className="relative flex-1 py-12">
+        <section>
+          <header className="pb-5 border-b border-gray-200 sm:flex sm:justify-between sm:items-end">
+            <div>
+              <h3 className="text-lg leading-6 text-gray-900 font-headings">Arkadiko Balances</h3>
+              <p className="max-w-3xl mt-2 text-sm text-gray-500">
+                An overview of all Arkadiko smart contracts and their balances
+              </p>
             </div>
+          </header>
 
-            <div className="mt-5">
+          <div className="mt-4">
+            <div className="min-w-full overflow-hidden overflow-x-auto align-middle shadow sm:rounded-lg">
               <table className="min-w-full divide-y divide-gray-200">
                 <thead>
                   <tr>
@@ -69,6 +133,9 @@ export const Balances = () => {
                     <th className="px-6 py-3 text-xs font-medium tracking-wider text-left text-gray-500 uppercase bg-gray-50">
                       xSTX Balance
                     </th>
+                    <th className="px-6 py-3 text-xs font-medium tracking-wider text-left text-gray-500 uppercase bg-gray-50">
+                      Contract Full name
+                    </th>
                   </tr>
                 </thead>
                 <tbody className="bg-white divide-y divide-gray-200">
@@ -76,10 +143,9 @@ export const Balances = () => {
                 </tbody>
               </table>
             </div>
-
           </div>
-        </div>
+        </section>
       </main>
-    </Box>
+    </Container>
   );
 };

--- a/web/components/smart-contract-balance.tsx
+++ b/web/components/smart-contract-balance.tsx
@@ -1,7 +1,9 @@
 import React, { useEffect, useState } from 'react';
 import { getRPCClient } from '@common/utils';
+import { Tooltip } from '@blockstack/ui';
+import { InformationCircleIcon } from '@heroicons/react/solid';
 
-export const SmartContractBalance = ({ address }) => {
+export const SmartContractBalance = ({ address, description, name }) => {
   const [stxBalance, setStxBalance] = useState(0.0);
   const [dikoBalance, setDikoBalance] = useState(0.0);
   const [usdaBalance, setUsdaBalance] = useState(0.0);
@@ -57,7 +59,12 @@ export const SmartContractBalance = ({ address }) => {
   return (
     <tr className="bg-white">
       <td className="px-6 py-4 text-sm text-left text-gray-500 whitespace-nowrap">
-        {address}
+        <div className="flex items-center">
+          {name}    
+          <Tooltip shouldWrapChildren={true} label={`${description}`}>
+            <InformationCircleIcon className="w-5 h-5 ml-2 text-gray-400" aria-hidden="true" />
+          </Tooltip>
+        </div>
       </td>
       <td className="px-6 py-4 text-sm text-left text-gray-500 whitespace-nowrap">
         {stxBalance.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 6 })} STX
@@ -73,6 +80,9 @@ export const SmartContractBalance = ({ address }) => {
       </td>
       <td className="px-6 py-4 text-sm text-left text-gray-500 whitespace-nowrap">
         {xStxBalance.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 6 })} xSTX
+      </td>
+      <td className="px-6 py-4 text-sm text-left text-gray-500 whitespace-nowrap">
+        {address}
       </td>
     </tr>
   )


### PR DESCRIPTION
![Screen Shot 2021-11-02 at 7 02 55 AM](https://user-images.githubusercontent.com/1909957/139800646-da738693-2800-4ce6-85d9-9d3ae781b963.png)

Feel free to adjust copy.

Also, it would be nice to have a `—` when data is not applicable. For example: 
![Screen Shot 2021-11-02 at 7 07 01 AM](https://user-images.githubusercontent.com/1909957/139801154-672c6a3e-7e4d-4661-ab56-f5c5e87dbf08.png)

I managed to do it for STX Balance but not for the rest of them.
