### PR TITLE
feat: add Modal component

### DIFF
--- a/web/components/auction-group.tsx
+++ b/web/components/auction-group.tsx
@@ -118,8 +118,8 @@ export const AuctionGroup: React.FC<AuctionProps[]> = ({ auctions, stacksTipHeig
         buttonAction={addBid}
       >
         <p className="text-sm text-center text-gray-500">
-          Bidding ${(preferredBid + 0.49).toFixed(0)} will close the lot and assign you
-          the collateral.
+          Bidding ${(preferredBid + 0.49).toFixed(0)} will close the lot and assign you the
+          collateral.
         </p>
 
         {/* TODO: replace this input with InputAmount component (+ clickMax function) */}
@@ -144,7 +144,7 @@ export const AuctionGroup: React.FC<AuctionProps[]> = ({ auctions, stacksTipHeig
           </div>
         </div>
       </Modal>
-      
+
       <div className="flex flex-col mt-2">
         <div className="min-w-full overflow-hidden overflow-x-auto align-middle shadow sm:rounded-lg">
           <table className="min-w-full divide-y divide-gray-200">

--- a/web/components/auction-group.tsx
+++ b/web/components/auction-group.tsx
@@ -1,6 +1,6 @@
 import React, { useContext, useState, useEffect } from 'react';
 import { Auction } from './auction';
-import { Modal } from '@blockstack/ui';
+import { Modal } from '@components/ui/modal';
 import {
   AnchorMode,
   contractPrincipalCV,
@@ -30,9 +30,9 @@ export const AuctionGroup: React.FC<AuctionProps[]> = ({ auctions, stacksTipHeig
   const [bidAuctionId, setBidAuctionId] = useState(0);
   const [bidLotId, setBidLotId] = useState(0);
   const [preferredBid, setPreferredBid] = useState(0);
+  const [state, setState] = useContext(AppContext);
   const contractAddress = process.env.REACT_APP_CONTRACT_ADDRESS || '';
   const stxAddress = useSTXAddress();
-  const [state, setState] = useContext(AppContext);
 
   useEffect(() => {
     if (state.currentTxStatus === 'success') {
@@ -109,90 +109,42 @@ export const AuctionGroup: React.FC<AuctionProps[]> = ({ auctions, stacksTipHeig
   };
 
   return (
-    <div className="hidden sm:block">
-      <Modal isOpen={showBidModal}>
-        <div className="flex px-4 pt-4 pb-20 text-center sm:block sm:p-0">
-          <div
-            className="inline-block px-2 pt-5 pb-4 overflow-hidden text-left align-bottom bg-white rounded-lg sm:my-8 sm:align-middle sm:max-w-sm sm:w-full sm:p-6"
-            role="dialog"
-            aria-modal="true"
-            aria-labelledby="modal-headline"
-          >
-            <div>
-              <div className="flex items-center justify-center w-12 h-12 mx-auto bg-green-100 rounded-full">
-                <svg
-                  className="w-6 h-6 text-green-600"
-                  xmlns="http://www.w3.org/2000/svg"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                  aria-hidden="true"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth="2"
-                    d="M5 13l4 4L19 7"
-                  />
-                </svg>
-              </div>
-              <div className="mt-3 text-center sm:mt-5">
-                <h3
-                  className="text-lg font-medium leading-6 text-gray-900 font-headings"
-                  id="modal-headline"
-                >
-                  Bid on Auction Lot
-                </h3>
-                <div className="mt-2">
-                  <p className="text-sm text-gray-500">
-                    Bidding ${(preferredBid + 0.49).toFixed(0)} will close the lot and assign you
-                    the collateral.
-                  </p>
+    <>
+      <Modal
+        open={showBidModal}
+        title="Bid on Auction Lot"
+        closeModal={setShowBidModal(false)}
+        buttonText="Add Bid"
+        buttonAction={addBid}
+      >
+        <p className="text-sm text-center text-gray-500">
+          Bidding ${(preferredBid + 0.49).toFixed(0)} will close the lot and assign you
+          the collateral.
+        </p>
 
-                  <div className="relative mt-4 rounded-md shadow-sm">
-                    <div className="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">
-                      $
-                    </div>
-                    <input
-                      type="text"
-                      name="stx"
-                      id="stxAmount"
-                      value={bidAmount}
-                      onChange={onInputChange}
-                      className="block w-full pr-12 border-gray-300 rounded-md focus:ring-indigo-500 focus:border-indigo-500 pl-7 sm:text-sm"
-                      placeholder="0.00"
-                      aria-describedby="stx-currency"
-                    />
-                    <div className="absolute inset-y-0 right-0 flex items-center pr-3 pointer-events-none">
-                      <span className="text-gray-500 sm:text-sm" id="stx-currency">
-                        USDA
-                      </span>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div className="mt-5 sm:mt-6">
-              <button
-                type="button"
-                onClick={() => addBid()}
-                className="inline-flex justify-center w-full px-4 py-2 mb-5 text-base font-medium text-white bg-indigo-600 border border-transparent rounded-md shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:text-sm"
-              >
-                Add bid
-              </button>
-
-              <button
-                type="button"
-                onClick={() => setShowBidModal(false)}
-                className="inline-flex justify-center w-full px-4 py-2 text-base font-medium text-white bg-gray-600 border border-transparent rounded-md shadow-sm hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500 sm:text-sm"
-              >
-                Close
-              </button>
-            </div>
+        {/* TODO: replace this input with InputAmount component (+ clickMax function) */}
+        <div className="relative mt-4 rounded-md shadow-sm">
+          <div className="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">
+            $
+          </div>
+          <input
+            type="text"
+            name="stx"
+            id="stxAmount"
+            value={bidAmount}
+            onChange={onInputChange}
+            className="block w-full pr-12 border-gray-300 rounded-md focus:ring-indigo-500 focus:border-indigo-500 pl-7 sm:text-sm"
+            placeholder="0.00"
+            aria-describedby="stx-currency"
+          />
+          <div className="absolute inset-y-0 right-0 flex items-center pr-3 pointer-events-none">
+            <span className="text-gray-500 sm:text-sm" id="stx-currency">
+              USDA
+            </span>
           </div>
         </div>
       </Modal>
-
+      
       <div className="flex flex-col mt-2">
         <div className="min-w-full overflow-hidden overflow-x-auto align-middle shadow sm:rounded-lg">
           <table className="min-w-full divide-y divide-gray-200">
@@ -223,6 +175,6 @@ export const AuctionGroup: React.FC<AuctionProps[]> = ({ auctions, stacksTipHeig
           </table>
         </div>
       </div>
-    </div>
+    </>
   );
 };

--- a/web/components/input-amount.tsx
+++ b/web/components/input-amount.tsx
@@ -11,7 +11,7 @@ interface InputAmountProps {
   onClickMax: (event: any) => void;
 }
 
-export const InputAmount: React.FC<InputAmountProps> = React.forwardRef(({
+export const InputAmount = React.forwardRef<HTMLInputElement, InputAmountProps>(({
   balance,
   token,
   inputName,

--- a/web/components/input-amount.tsx
+++ b/web/components/input-amount.tsx
@@ -11,7 +11,7 @@ interface InputAmountProps {
   onClickMax: (event: any) => void;
 }
 
-export const InputAmount: React.FC<InputAmountProps> = ({
+export const InputAmount: React.FC<InputAmountProps> = React.forwardRef(({
   balance,
   token,
   inputName,
@@ -19,14 +19,14 @@ export const InputAmount: React.FC<InputAmountProps> = ({
   inputValue,
   inputLabel,
   onInputChange,
-  onClickMax,
-}) => {
+  onClickMax
+}, ref) => {
   return (
     <div className="relative flex flex-col">
       <span className="text-xs text-left text-gray-600">
         Available amount {balance} {token}
       </span>
-      <div className="inline-flex items-center w-full h-10 min-w-0 mt-2 mb-2 border border-gray-300 rounded-md focus-within:ring-indigo-500 focus-within:border-indigo-500">
+      <div className="inline-flex items-center w-full min-w-0 mt-2 mb-2 border border-gray-300 rounded-md focus-within:ring-indigo-500 focus-within:border-indigo-500">
         <input
           type="text"
           inputMode="decimal"
@@ -40,8 +40,9 @@ export const InputAmount: React.FC<InputAmountProps> = ({
           className="flex-1 min-w-0 px-3 mr-2 border-0 rounded-md sm:text-sm focus:outline-none focus:ring-0"
           value={inputValue}
           onChange={onInputChange}
+          ref={ref}
         />
-        <div className="flex-shrink-0 mx-1 ml-auto text-sm">
+        <div className="flex-shrink-0 ml-auto mr-2 text-sm">
           <div className="flex items-center min-w-0">
             <span className="text-gray-400 sm:text-sm">{token}</span>
             <div className="w-px h-3 mx-2 bg-gray-400"></div>
@@ -58,4 +59,4 @@ export const InputAmount: React.FC<InputAmountProps> = ({
       </div>
     </div>
   );
-};
+});

--- a/web/components/input-amount.tsx
+++ b/web/components/input-amount.tsx
@@ -11,52 +11,48 @@ interface InputAmountProps {
   onClickMax: (event: any) => void;
 }
 
-export const InputAmount = React.forwardRef<HTMLInputElement, InputAmountProps>(({
-  balance,
-  token,
-  inputName,
-  inputId,
-  inputValue,
-  inputLabel,
-  onInputChange,
-  onClickMax
-}, ref) => {
-  return (
-    <div className="relative flex flex-col">
-      <span className="text-xs text-left text-gray-600">
-        Available amount {balance} {token}
-      </span>
-      <div className="inline-flex items-center w-full min-w-0 mt-2 mb-2 border border-gray-300 rounded-md focus-within:ring-indigo-500 focus-within:border-indigo-500">
-        <input
-          type="text"
-          inputMode="decimal"
-          autoComplete="off"
-          autoCorrect="off"
-          pattern="^[0-9]*[.,]?[0-9]*$"
-          placeholder="0.0"
-          name={inputName}
-          id={inputId}
-          aria-label={inputLabel}
-          className="flex-1 min-w-0 px-3 mr-2 border-0 rounded-md sm:text-sm focus:outline-none focus:ring-0"
-          value={inputValue}
-          onChange={onInputChange}
-          ref={ref}
-        />
-        <div className="flex-shrink-0 ml-auto mr-2 text-sm">
-          <div className="flex items-center min-w-0">
-            <span className="text-gray-400 sm:text-sm">{token}</span>
-            <div className="w-px h-3 mx-2 bg-gray-400"></div>
-            <button
-              type="button"
-              onClick={onClickMax}
-              className="p-1 text-xs font-semibold text-indigo-600 bg-indigo-100 rounded-md hover:text-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-0 focus:ring-indigo-500"
-            >
-              Max.
-            </button>
+export const InputAmount = React.forwardRef<HTMLInputElement, InputAmountProps>(
+  (
+    { balance, token, inputName, inputId, inputValue, inputLabel, onInputChange, onClickMax },
+    ref
+  ) => {
+    return (
+      <div className="relative flex flex-col">
+        <span className="text-xs text-left text-gray-600">
+          Available amount {balance} {token}
+        </span>
+        <div className="inline-flex items-center w-full min-w-0 mt-2 mb-2 border border-gray-300 rounded-md focus-within:ring-indigo-500 focus-within:border-indigo-500">
+          <input
+            type="text"
+            inputMode="decimal"
+            autoComplete="off"
+            autoCorrect="off"
+            pattern="^[0-9]*[.,]?[0-9]*$"
+            placeholder="0.0"
+            name={inputName}
+            id={inputId}
+            aria-label={inputLabel}
+            className="flex-1 min-w-0 px-3 mr-2 border-0 rounded-md sm:text-sm focus:outline-none focus:ring-0"
+            value={inputValue}
+            onChange={onInputChange}
+            ref={ref}
+          />
+          <div className="flex-shrink-0 ml-auto mr-2 text-sm">
+            <div className="flex items-center min-w-0">
+              <span className="text-gray-400 sm:text-sm">{token}</span>
+              <div className="w-px h-3 mx-2 bg-gray-400"></div>
+              <button
+                type="button"
+                onClick={onClickMax}
+                className="p-1 text-xs font-semibold text-indigo-600 bg-indigo-100 rounded-md hover:text-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-0 focus:ring-indigo-500"
+              >
+                Max.
+              </button>
+            </div>
           </div>
+          <label className="sr-only">{inputLabel}</label>
         </div>
-        <label className="sr-only">{inputLabel}</label>
       </div>
-    </div>
-  );
-});
+    );
+  }
+);

--- a/web/components/stake-diko-modal.tsx
+++ b/web/components/stake-diko-modal.tsx
@@ -17,13 +17,8 @@ import { stacksNetwork as network } from '@common/utils';
 import { useConnect } from '@stacks/connect-react';
 import { Alert } from './ui/alert';
 
-interface StakeDikoModalProps {
-  showStakeModal: boolean;
-  setShowStakeModal: () => void;
-  apy: number;
-}
 
-export const StakeDikoModal: React.FC<StakeDikoModalProps> = ({ showStakeModal, setShowStakeModal, apy }) => {
+export const StakeDikoModal = ({ showStakeModal, setShowStakeModal, apy }) => {
   const [state, setState] = useContext(AppContext);
   const [errors, setErrors] = useState<string[]>([]);
   const [stakeAmount, setStakeAmount] = useState('');

--- a/web/components/stake-diko-modal.tsx
+++ b/web/components/stake-diko-modal.tsx
@@ -17,7 +17,6 @@ import { stacksNetwork as network } from '@common/utils';
 import { useConnect } from '@stacks/connect-react';
 import { Alert } from './ui/alert';
 
-
 export const StakeDikoModal = ({ showStakeModal, setShowStakeModal, apy }) => {
   const [state, setState] = useContext(AppContext);
   const [errors, setErrors] = useState<string[]>([]);

--- a/web/components/stake-diko-modal.tsx
+++ b/web/components/stake-diko-modal.tsx
@@ -1,6 +1,5 @@
-import React, { useContext, useState } from 'react';
-import { Modal } from '@blockstack/ui';
-import { XIcon } from '@heroicons/react/outline';
+import React, { useContext, useState, useRef } from 'react';
+import { Modal } from '@components/ui/modal';
 import { tokenList } from '@components/token-swap-list';
 import { AppContext } from '@common/context';
 import { InputAmount } from './input-amount';
@@ -18,13 +17,20 @@ import { stacksNetwork as network } from '@common/utils';
 import { useConnect } from '@stacks/connect-react';
 import { Alert } from './ui/alert';
 
-export const StakeDikoModal = ({ showStakeModal, setShowStakeModal, apy }) => {
+interface StakeDikoModalProps {
+  showStakeModal: boolean;
+  setShowStakeModal: () => void;
+  apy: number;
+}
+
+export const StakeDikoModal: React.FC<StakeDikoModalProps> = ({ showStakeModal, setShowStakeModal, apy }) => {
   const [state, setState] = useContext(AppContext);
   const [errors, setErrors] = useState<string[]>([]);
   const [stakeAmount, setStakeAmount] = useState('');
   const stxAddress = useSTXAddress();
   const contractAddress = process.env.REACT_APP_CONTRACT_ADDRESS || '';
   const { doContractCall } = useConnect();
+  const inputRef = useRef<HTMLInputElement>(null);
 
   const stakeMaxAmount = () => {
     setStakeAmount(state.balance['diko'] / 1000000);
@@ -82,90 +88,51 @@ export const StakeDikoModal = ({ showStakeModal, setShowStakeModal, apy }) => {
   };
 
   return (
-    <Modal isOpen={showStakeModal}>
-      <div className="flex items-end justify-center px-4 pt-6 pb-6 text-center sm:block sm:p-0">
-        {errors.length > 0 ? (
-          <Alert type={Alert.type.ERROR}>
-            <p>{errors[0]}</p>
-          </Alert>
-        ) : null}
+    <Modal
+      open={showStakeModal}
+      title="Stake DIKO"
+      icon={<img className="w-10 h-10 rounded-full" src={tokenList[1].logo} alt="" />}
+      closeModal={setShowStakeModal(false)}
+      buttonText="Stake"
+      buttonAction={stakeDiko}
+      initialFocus={inputRef}
+    >
+      {errors.length > 0 ? (
+        <Alert type={Alert.type.ERROR}>
+          <p>{errors[0]}</p>
+        </Alert>
+      ) : null}
 
-        <div
-          className="inline-block px-2 overflow-hidden text-left align-bottom bg-white rounded-lg sm:my-8 sm:align-middle sm:max-w-sm sm:w-full sm:p-6"
-          role="dialog"
-          aria-modal="true"
-          aria-labelledby="modal-headline"
-        >
-          <div className="absolute top-0 right-0 hidden pt-4 pr-4 sm:block">
-            <button
-              type="button"
-              className="text-gray-400 bg-white rounded-md hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
-              onClick={() => setShowStakeModal(false)}
-            >
-              <span className="sr-only">Close</span>
-              <XIcon className="w-6 h-6" aria-hidden="true" />
-            </button>
-          </div>
-          <div className="flex items-center justify-center mx-auto rounded-full">
-            <img className="w-10 h-10 rounded-full" src={tokenList[1].logo} alt="" />
-          </div>
-          <div>
-            <div className="mt-3 text-center sm:mt-5">
-              <h3
-                className="text-lg font-medium leading-6 text-gray-900 font-headings"
-                id="modal-headline"
-              >
-                Stake DIKO
-              </h3>
-              <p className="mt-3 text-sm text-gray-500">
-                Stake DIKO tokens at {apy}% (estimated APY) and start earning rewards now.
-              </p>
-              <div className="mt-4">
-                <Alert>
-                  <p>
-                    Once you have staked your DIKO tokens, they will be locked for at least 10 days
-                    (cooldown period).
-                  </p>
-                  <p className="mt-1">
-                    <span className="font-semibold">Reminder</span>: The cooldown has to be started
-                    manually.
-                  </p>
-                </Alert>
-              </div>
-              <div className="mt-6">
-                <InputAmount
-                  balance={microToReadable(state.balance['diko']).toLocaleString(undefined, {
-                    minimumFractionDigits: 2,
-                    maximumFractionDigits: 6,
-                  })}
-                  token="DIKO"
-                  inputName="stakeDiko"
-                  inputId="stakeAmount"
-                  inputValue={stakeAmount}
-                  inputLabel="Stack DIKO"
-                  onInputChange={onInputStakeChange}
-                  onClickMax={stakeMaxAmount}
-                />
-              </div>
-            </div>
-          </div>
-          <div className="mt-5 sm:mt-4 sm:flex sm:flex-row-reverse">
-            <button
-              type="button"
-              className="inline-flex justify-center w-full px-4 py-2 text-base font-medium text-white bg-indigo-600 border border-transparent rounded-md shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:ml-3 sm:w-auto sm:text-sm"
-              onClick={() => stakeDiko()}
-            >
-              Stake
-            </button>
-            <button
-              type="button"
-              className="inline-flex justify-center w-full px-4 py-2 mt-3 text-base font-medium text-gray-700 bg-white border border-gray-300 rounded-md shadow-sm hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:w-auto sm:text-sm"
-              onClick={() => setShowStakeModal(false)}
-            >
-              Cancel
-            </button>
-          </div>
-        </div>
+      <p className="mt-3 text-sm text-center text-gray-500">
+        Stake DIKO tokens at {apy}% (estimated APY) and start earning rewards now.
+      </p>
+      <div className="mt-4">
+        <Alert>
+          <p>
+            Once you have staked your DIKO tokens, they will be locked for at least 10 days
+            (cooldown period).
+          </p>
+          <p className="mt-1">
+            <span className="font-semibold">Reminder</span>: The cooldown has to be started
+            manually.
+          </p>
+        </Alert>
+      </div>
+      <div className="mt-6">
+        <InputAmount
+          balance={microToReadable(state.balance['diko']).toLocaleString(undefined, {
+            minimumFractionDigits: 2,
+            maximumFractionDigits: 6,
+          })}
+          token="DIKO"
+          inputName="stakeDiko"
+          inputId="stakeAmount"
+          inputValue={stakeAmount}
+          inputLabel="Stake DIKO"
+          onInputChange={onInputStakeChange}
+          onClickMax={stakeMaxAmount}
+          ref={inputRef}
+        />
       </div>
     </Modal>
   );

--- a/web/components/stake-lp-modal.tsx
+++ b/web/components/stake-lp-modal.tsx
@@ -23,8 +23,6 @@ export const StakeLpModal = ({
   apy,
   balanceName,
   tokenName,
-  lpPairTokenX,
-  lpPairTokenY,
 }) => {
   const [state, setState] = useContext(AppContext);
   const [errors, setErrors] = useState<string[]>([]);
@@ -101,6 +99,9 @@ export const StakeLpModal = ({
       anchorMode: AnchorMode.Any,
     });
   };
+
+  const lpPairTokenX = tokenList.findIndex(obj => obj.name == tokenName.split('/').slice(0, 1))
+  const lpPairTokenY = tokenList.findIndex(obj => obj.name == tokenName.split('/').slice(1))
 
   return (
     <Modal

--- a/web/components/stake-lp-modal.tsx
+++ b/web/components/stake-lp-modal.tsx
@@ -1,6 +1,5 @@
-import React, { useContext, useState } from 'react';
-import { Modal } from '@blockstack/ui';
-import { XIcon } from '@heroicons/react/outline';
+import React, { useContext, useState, useRef } from 'react';
+import { Modal } from '@components/ui/modal';
 import { tokenList } from '@components/token-swap-list';
 import { AppContext } from '@common/context';
 import { InputAmount } from './input-amount';
@@ -24,6 +23,8 @@ export const StakeLpModal = ({
   apy,
   balanceName,
   tokenName,
+  lpPairTokenX,
+  lpPairTokenY,
 }) => {
   const [state, setState] = useContext(AppContext);
   const [errors, setErrors] = useState<string[]>([]);
@@ -31,6 +32,7 @@ export const StakeLpModal = ({
   const stxAddress = useSTXAddress();
   const contractAddress = process.env.REACT_APP_CONTRACT_ADDRESS || '';
   const { doContractCall } = useConnect();
+  const inputRef = useRef<HTMLInputElement>(null);
 
   const stakeMaxAmount = () => {
     setStakeAmount(state.balance[balanceName] / 1000000);
@@ -101,83 +103,53 @@ export const StakeLpModal = ({
   };
 
   return (
-    <Modal isOpen={showStakeModal}>
-      <div className="flex items-end justify-center px-4 pt-6 pb-6 text-center sm:block sm:p-0">
-        {errors.length > 0 ? (
-          <div className="mt-4">
-            <Alert type={Alert.type.ERROR}>
-              <p>{errors[0]}</p>
-            </Alert>
-          </div>
-        ) : (
-          ``
-        )}
-
-        <div
-          className="inline-block px-2 overflow-hidden text-left align-bottom bg-white rounded-lg sm:my-8 sm:align-middle sm:max-w-sm sm:w-full sm:p-6"
-          role="dialog"
-          aria-modal="true"
-          aria-labelledby="modal-headline"
-        >
-          <div className="absolute top-0 right-0 hidden pt-4 pr-4 sm:block">
-            <button
-              type="button"
-              className="text-gray-400 bg-white rounded-md hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
-              onClick={() => setShowStakeModal(false)}
-            >
-              <span className="sr-only">Close</span>
-              <XIcon className="w-6 h-6" aria-hidden="true" />
-            </button>
-          </div>
-          <div className="flex items-center justify-center mx-auto rounded-full">
-            <img className="w-10 h-10 rounded-full" src={tokenList[1].logo} alt="" />
-          </div>
-          <div>
-            <div className="mt-3 text-center sm:mt-5">
-              <h3
-                className="text-lg font-medium leading-6 text-gray-900 font-headings"
-                id="modal-headline"
-              >
-                Stake {tokenName} LP Tokens
-              </h3>
-              <p className="mt-3 text-sm text-gray-500">
-                Stake your {tokenName} LP tokens at {apy}% (estimated APY) and start earning rewards
-                now.
-              </p>
-              <div className="mt-6">
-                <InputAmount
-                  balance={microToReadable(state.balance[balanceName]).toLocaleString(undefined, {
-                    minimumFractionDigits: 2,
-                    maximumFractionDigits: 6,
-                  })}
-                  token={tokenName}
-                  inputName="stakeDiko"
-                  inputId="stakeAmount"
-                  inputValue={stakeAmount}
-                  inputLabel={`Stake ${tokenName}`}
-                  onInputChange={onInputStakeChange}
-                  onClickMax={stakeMaxAmount}
-                />
-              </div>
-            </div>
-          </div>
-          <div className="mt-5 sm:mt-4 sm:flex sm:flex-row-reverse">
-            <button
-              type="button"
-              className="inline-flex justify-center w-full px-4 py-2 text-base font-medium text-white bg-indigo-600 border border-transparent rounded-md shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:ml-3 sm:w-auto sm:text-sm"
-              onClick={() => stake()}
-            >
-              Stake
-            </button>
-            <button
-              type="button"
-              className="inline-flex justify-center w-full px-4 py-2 mt-3 text-base font-medium text-gray-700 bg-white border border-gray-300 rounded-md shadow-sm hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:w-auto sm:text-sm"
-              onClick={() => setShowStakeModal(false)}
-            >
-              Cancel
-            </button>
-          </div>
+    <Modal
+      open={showStakeModal}
+      title={`Stake ${tokenName} LP Tokens`}
+      icon={
+        <div className="flex -space-x-2 overflow-hidden">
+          <img
+            className="inline-block w-8 h-8 rounded-full ring-2 ring-white"
+            src={tokenList[lpPairTokenX].logo}
+            alt=""
+          />
+          <img
+            className="inline-block w-8 h-8 rounded-full ring-2 ring-white"
+            src={tokenList[lpPairTokenY].logo}
+            alt=""
+          />
         </div>
+      }
+      closeModal={setShowStakeModal(false)}
+      buttonText="Stake"
+      buttonAction={stake}
+      initialFocus={inputRef}
+    >
+      {errors.length > 0 ? (
+        <Alert type={Alert.type.ERROR}>
+          <p>{errors[0]}</p>
+        </Alert>
+      ) : null}
+
+      <p className="mt-3 text-sm text-center text-gray-500">
+        Stake your {tokenName} LP tokens at {apy}% (estimated APY) and start earning rewards
+        now.
+      </p>
+      <div className="mt-6">
+        <InputAmount
+          balance={microToReadable(state.balance[balanceName]).toLocaleString(undefined, {
+            minimumFractionDigits: 2,
+            maximumFractionDigits: 6,
+          })}
+          token={tokenName}
+          inputName="stakeDiko"
+          inputId="stakeAmount"
+          inputValue={stakeAmount}
+          inputLabel={`Stake ${tokenName}`}
+          onInputChange={onInputStakeChange}
+          onClickMax={stakeMaxAmount}
+          ref={inputRef}
+        />
       </div>
     </Modal>
   );

--- a/web/components/stake-lp-modal.tsx
+++ b/web/components/stake-lp-modal.tsx
@@ -100,8 +100,8 @@ export const StakeLpModal = ({
     });
   };
 
-  const lpPairTokenX = tokenList.findIndex(obj => obj.name == tokenName.split('/').slice(0, 1))
-  const lpPairTokenY = tokenList.findIndex(obj => obj.name == tokenName.split('/').slice(1))
+  const lpPairTokenX = tokenList.findIndex(obj => obj.name == tokenName.split('/').slice(0, 1));
+  const lpPairTokenY = tokenList.findIndex(obj => obj.name == tokenName.split('/').slice(1));
 
   return (
     <Modal
@@ -143,8 +143,8 @@ export const StakeLpModal = ({
             maximumFractionDigits: 6,
           })}
           token={tokenName}
-          inputName="stakeDiko"
-          inputId="stakeAmount"
+          inputName={`stakeLp-${tokenName}`}
+          inputId={`stakeAmount-${tokenName}`}
           inputValue={stakeAmount}
           inputLabel={`Stake ${tokenName}`}
           onInputChange={onInputStakeChange}

--- a/web/components/stake-lp-modal.tsx
+++ b/web/components/stake-lp-modal.tsx
@@ -133,8 +133,7 @@ export const StakeLpModal = ({
       ) : null}
 
       <p className="mt-3 text-sm text-center text-gray-500">
-        Stake your {tokenName} LP tokens at {apy}% (estimated APY) and start earning rewards
-        now.
+        Stake your {tokenName} LP tokens at {apy}% (estimated APY) and start earning rewards now.
       </p>
       <div className="mt-6">
         <InputAmount

--- a/web/components/stake.tsx
+++ b/web/components/stake.tsx
@@ -578,6 +578,8 @@ export const Stake = () => {
         apy={dikoUsdaLpApy}
         balanceName={'dikousda'}
         tokenName={'DIKO/USDA'}
+        lpPairTokenX={1}
+        lpPairTokenY={0}
       />
 
       <StakeLpModal
@@ -586,6 +588,8 @@ export const Stake = () => {
         apy={stxUsdaLpApy}
         balanceName={'wstxusda'}
         tokenName={'STX/USDA'}
+        lpPairTokenX={2}
+        lpPairTokenY={0}
       />
 
       <StakeLpModal
@@ -594,6 +598,8 @@ export const Stake = () => {
         apy={stxDikoLpApy}
         balanceName={'wstxdiko'}
         tokenName={'STX/DIKO'}
+        lpPairTokenX={2}
+        lpPairTokenY={1}
       />
 
       <UnstakeLpModal

--- a/web/components/stake.tsx
+++ b/web/components/stake.tsx
@@ -626,9 +626,7 @@ export const Stake = () => {
               <Alert title="Unstaked LP tokens">
                 <p>👀 We noticed that your wallet contains LP Tokens that are not staked yet.</p>
                 <p className="mt-1">
-                  If you want to stake them, pick the appropriate token in the table below and hit
-                  the <DotsVerticalIcon className="inline w-4 h-4" aria-hidden="true" /> icon to
-                  open the actions menu and initiate staking.
+                  If you want to stake them, pick the appropriate token in the table below, hit the Actions dropdown button and choose Stake LP to initiate staking.
                 </p>
               </Alert>
             ) : null}

--- a/web/components/stake.tsx
+++ b/web/components/stake.tsx
@@ -63,7 +63,6 @@ export const Stake = () => {
   const [loadingData, setLoadingData] = useState(true);
   const [hasUnstakedTokens, setHasUnstakedTokens] = useState(false);
   const [emissionsStarted, setEmissionsStarted] = useState(false);
-  const [canStakeLp, _] = useState(false);
 
   const [stxDikoPoolInfo, setStxDikoPoolInfo] = useState(0);
   const [stxUsdaPoolInfo, setStxUsdaPoolInfo] = useState(0);
@@ -578,8 +577,6 @@ export const Stake = () => {
         apy={dikoUsdaLpApy}
         balanceName={'dikousda'}
         tokenName={'DIKO/USDA'}
-        lpPairTokenX={1}
-        lpPairTokenY={0}
       />
 
       <StakeLpModal
@@ -588,8 +585,6 @@ export const Stake = () => {
         apy={stxUsdaLpApy}
         balanceName={'wstxusda'}
         tokenName={'STX/USDA'}
-        lpPairTokenX={2}
-        lpPairTokenY={0}
       />
 
       <StakeLpModal
@@ -598,8 +593,6 @@ export const Stake = () => {
         apy={stxDikoLpApy}
         balanceName={'wstxdiko'}
         tokenName={'STX/DIKO'}
-        lpPairTokenX={2}
-        lpPairTokenY={1}
       />
 
       <UnstakeLpModal

--- a/web/components/stake.tsx
+++ b/web/components/stake.tsx
@@ -157,8 +157,8 @@ export const Stake = () => {
       // Get pair details
       const pairDetailsCall = await callReadOnlyFunction({
         contractAddress,
-        contractName: "arkadiko-swap-v2-1",
-        functionName: "get-pair-details",
+        contractName: 'arkadiko-swap-v2-1',
+        functionName: 'get-pair-details',
         functionArgs: [
           contractPrincipalCV(contractAddress, tokenXContract),
           contractPrincipalCV(contractAddress, tokenYContract),

--- a/web/components/stake.tsx
+++ b/web/components/stake.tsx
@@ -626,7 +626,8 @@ export const Stake = () => {
               <Alert title="Unstaked LP tokens">
                 <p>👀 We noticed that your wallet contains LP Tokens that are not staked yet.</p>
                 <p className="mt-1">
-                  If you want to stake them, pick the appropriate token in the table below, hit the Actions dropdown button and choose Stake LP to initiate staking.
+                  If you want to stake them, pick the appropriate token in the table below, hit the
+                  Actions dropdown button and choose Stake LP to initiate staking.
                 </p>
               </Alert>
             ) : null}

--- a/web/components/ui/modal.tsx
+++ b/web/components/ui/modal.tsx
@@ -1,4 +1,3 @@
-
 import React, { ReactNode, Fragment, useRef } from 'react';
 import { Dialog, Transition } from '@headlessui/react';
 import { XIcon } from '@heroicons/react/outline';
@@ -14,12 +13,26 @@ type Props = {
   initialFocus: React.MutableRefObject<HTMLElement | null> | undefined;
 };
 
-export function Modal({ open, children, title, icon, closeModal, buttonText, buttonAction, initialFocus }: Props) {
-  const actionButtonRef = useRef(null)
+export function Modal({
+  open,
+  children,
+  title,
+  icon,
+  closeModal,
+  buttonText,
+  buttonAction,
+  initialFocus,
+}: Props) {
+  const actionButtonRef = useRef(null);
 
   return (
     <Transition.Root show={open} as={Fragment}>
-      <Dialog as="div" className="fixed inset-0 z-50 overflow-y-auto" initialFocus={initialFocus} onClose={() => closeModal}>
+      <Dialog
+        as="div"
+        className="fixed inset-0 z-50 overflow-y-auto"
+        initialFocus={initialFocus}
+        onClose={() => closeModal}
+      >
         <div className="flex items-end justify-center min-h-screen px-4 pt-4 pb-20 text-center sm:block sm:p-0">
           <Transition.Child
             as={Fragment}
@@ -64,12 +77,13 @@ export function Modal({ open, children, title, icon, closeModal, buttonText, but
                   </div>
                 ) : null}
                 <div className="mt-3 sm:mt-5">
-                  <Dialog.Title as="h3" className="text-lg leading-6 text-center text-gray-900 font-headings">
+                  <Dialog.Title
+                    as="h3"
+                    className="text-lg leading-6 text-center text-gray-900 font-headings"
+                  >
                     {title}
                   </Dialog.Title>
-                  <div className="mt-2">
-                    {children}
-                  </div>
+                  <div className="mt-2">{children}</div>
                 </div>
               </div>
               <div className="mt-5 sm:mt-6 sm:grid sm:grid-cols-2 sm:gap-3 sm:grid-flow-row-dense">

--- a/web/components/ui/modal.tsx
+++ b/web/components/ui/modal.tsx
@@ -1,0 +1,97 @@
+
+import React, { ReactNode, Fragment, useRef } from 'react';
+import { Dialog, Transition } from '@headlessui/react';
+import { XIcon } from '@heroicons/react/outline';
+
+type Props = {
+  open: boolean;
+  closeModal: () => void;
+  children: ReactNode;
+  title: string;
+  icon?: ReactNode;
+  buttonText: string;
+  buttonAction: () => void;
+};
+
+export function Modal({ open, children, title, icon, closeModal, buttonText, buttonAction }: Props) {
+  const actionButtonRef = useRef(null)
+
+  return (
+    <Transition.Root show={open} as={Fragment}>
+      <Dialog as="div" className="fixed inset-0 z-50 overflow-y-auto" initialFocus={actionButtonRef} onClose={() => closeModal}>
+        <div className="flex items-end justify-center min-h-screen px-4 pt-4 pb-20 text-center sm:block sm:p-0">
+          <Transition.Child
+            as={Fragment}
+            enter="ease-out duration-300"
+            enterFrom="opacity-0"
+            enterTo="opacity-100"
+            leave="ease-in duration-200"
+            leaveFrom="opacity-100"
+            leaveTo="opacity-0"
+          >
+            <Dialog.Overlay className="fixed inset-0 transition-opacity bg-gray-500 bg-opacity-75" />
+          </Transition.Child>
+
+          {/* This element is to trick the browser into centering the modal contents. */}
+          <span className="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true">
+            &#8203;
+          </span>
+          <Transition.Child
+            as={Fragment}
+            enter="ease-out duration-300"
+            enterFrom="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+            enterTo="opacity-100 translate-y-0 sm:scale-100"
+            leave="ease-in duration-200"
+            leaveFrom="opacity-100 translate-y-0 sm:scale-100"
+            leaveTo="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+          >
+            <div className="inline-block px-4 pt-5 pb-4 overflow-hidden text-left align-bottom transition-all transform bg-white rounded-lg shadow-xl sm:my-8 sm:align-middle sm:max-w-lg sm:w-full sm:p-6">
+              <div className="absolute top-0 right-0 hidden pt-4 pr-4 sm:block">
+                <button
+                  type="button"
+                  className="text-gray-400 bg-white rounded-md hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+                  onClick={() => closeModal}
+                >
+                  <span className="sr-only">Close</span>
+                  <XIcon className="w-6 h-6" aria-hidden="true" />
+                </button>
+              </div>
+              <div>
+                {icon ? (
+                  <div className="flex items-center justify-center mx-auto rounded-full">
+                    {icon}
+                  </div>
+                ) : null}
+                <div className="mt-3 text-center sm:mt-5">
+                  <Dialog.Title as="h3" className="text-lg leading-6 text-gray-900 font-headings">
+                    {title}
+                  </Dialog.Title>
+                  <div className="mt-2">
+                    {children}
+                  </div>
+                </div>
+              </div>
+              <div className="mt-5 sm:mt-6 sm:grid sm:grid-cols-2 sm:gap-3 sm:grid-flow-row-dense">
+                <button
+                  type="button"
+                  className="inline-flex justify-center w-full px-4 py-2 text-base font-medium text-white bg-indigo-600 border border-transparent rounded-md shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:col-start-2 sm:text-sm"
+                  onClick={() => buttonAction}
+                  ref={actionButtonRef}
+                >
+                  {buttonText}
+                </button>
+                <button
+                  type="button"
+                  className="inline-flex justify-center w-full px-4 py-2 mt-3 text-base font-medium text-gray-700 bg-white border border-gray-300 rounded-md shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:col-start-1 sm:text-sm"
+                  onClick={() => closeModal}
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          </Transition.Child>
+        </div>
+      </Dialog>
+    </Transition.Root>
+  );
+}

--- a/web/components/ui/modal.tsx
+++ b/web/components/ui/modal.tsx
@@ -10,7 +10,7 @@ type Props = {
   icon?: ReactNode;
   buttonText: string;
   buttonAction: () => void;
-  initialFocus: React.MutableRefObject<HTMLElement | null> | undefined;
+  initialFocus?: React.MutableRefObject<HTMLElement | null> | undefined;
 };
 
 export function Modal({

--- a/web/components/ui/modal.tsx
+++ b/web/components/ui/modal.tsx
@@ -11,14 +11,15 @@ type Props = {
   icon?: ReactNode;
   buttonText: string;
   buttonAction: () => void;
+  initialFocus: React.MutableRefObject<HTMLElement | null> | undefined;
 };
 
-export function Modal({ open, children, title, icon, closeModal, buttonText, buttonAction }: Props) {
+export function Modal({ open, children, title, icon, closeModal, buttonText, buttonAction, initialFocus }: Props) {
   const actionButtonRef = useRef(null)
 
   return (
     <Transition.Root show={open} as={Fragment}>
-      <Dialog as="div" className="fixed inset-0 z-50 overflow-y-auto" initialFocus={actionButtonRef} onClose={() => closeModal}>
+      <Dialog as="div" className="fixed inset-0 z-50 overflow-y-auto" initialFocus={initialFocus} onClose={() => closeModal}>
         <div className="flex items-end justify-center min-h-screen px-4 pt-4 pb-20 text-center sm:block sm:p-0">
           <Transition.Child
             as={Fragment}
@@ -62,8 +63,8 @@ export function Modal({ open, children, title, icon, closeModal, buttonText, but
                     {icon}
                   </div>
                 ) : null}
-                <div className="mt-3 text-center sm:mt-5">
-                  <Dialog.Title as="h3" className="text-lg leading-6 text-gray-900 font-headings">
+                <div className="mt-3 sm:mt-5">
+                  <Dialog.Title as="h3" className="text-lg leading-6 text-center text-gray-900 font-headings">
                     {title}
                   </Dialog.Title>
                   <div className="mt-2">

--- a/web/components/unstake-diko-modal.tsx
+++ b/web/components/unstake-diko-modal.tsx
@@ -1,6 +1,5 @@
-import React, { useContext, useState } from 'react';
-import { Modal } from '@blockstack/ui';
-import { XIcon } from '@heroicons/react/outline';
+import React, { useContext, useState, useRef } from 'react';
+import { Modal } from '@components/ui/modal';
 import { tokenList } from '@components/token-swap-list';
 import { AppContext } from '@common/context';
 import { InputAmount } from './input-amount';
@@ -9,14 +8,15 @@ import {
   AnchorMode,
   contractPrincipalCV,
   uintCV,
-  makeStandardFungiblePostCondition,
-  FungibleConditionCode,
   createAssetInfo,
+  FungibleConditionCode,
+  makeStandardFungiblePostCondition,
 } from '@stacks/transactions';
 import { useSTXAddress } from '@common/use-stx-address';
 import { stacksNetwork as network } from '@common/utils';
 import { useConnect } from '@stacks/connect-react';
 import { Alert } from './ui/alert';
+
 
 export const UnstakeDikoModal = ({ showUnstakeModal, setShowUnstakeModal, stakedAmount }) => {
   const [state, setState] = useContext(AppContext);
@@ -25,6 +25,7 @@ export const UnstakeDikoModal = ({ showUnstakeModal, setShowUnstakeModal, staked
   const stxAddress = useSTXAddress();
   const contractAddress = process.env.REACT_APP_CONTRACT_ADDRESS || '';
   const { doContractCall } = useConnect();
+  const inputRef = useRef<HTMLInputElement>(null);
 
   const unstakeDiko = async () => {
     const postConditions = [
@@ -80,84 +81,43 @@ export const UnstakeDikoModal = ({ showUnstakeModal, setShowUnstakeModal, staked
   };
 
   return (
-    <Modal isOpen={showUnstakeModal}>
-      <div className="flex items-end justify-center px-4 pt-6 pb-6 text-center sm:block sm:p-0">
-        {errors.length > 0 ? (
-          <div className="mt-4">
-            <Alert type={Alert.type.ERROR}>
-              {errors.map(txt => (
-                <p key={txt}>{txt}</p>
-              ))}
-            </Alert>
-          </div>
-        ) : null}
+    <Modal
+      open={showUnstakeModal}
+      title="Unstake DIKO"
+      icon={<img className="w-10 h-10 rounded-full" src={tokenList[1].logo} alt="" />}
+      closeModal={setShowUnstakeModal(false)}
+      buttonText="Unstake"
+      buttonAction={unstakeDiko}
+      initialFocus={inputRef}
+    >
+      {errors.length > 0 ? (
+        <Alert type={Alert.type.ERROR}>
+          {errors.map(txt => (
+            <p key={txt}>{txt}</p>
+          ))}
+        </Alert>
+      ) : null}
 
-        <div
-          className="inline-block px-2 overflow-hidden text-left align-bottom bg-white rounded-lg sm:my-8 sm:align-middle sm:max-w-sm sm:w-full sm:p-6"
-          role="dialog"
-          aria-modal="true"
-          aria-labelledby="modal-headline"
-        >
-          <div className="absolute top-0 right-0 hidden pt-4 pr-4 sm:block">
-            <button
-              type="button"
-              className="text-gray-400 bg-white rounded-md hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
-              onClick={() => setShowUnstakeModal(false)}
-            >
-              <span className="sr-only">Close</span>
-              <XIcon className="w-6 h-6" aria-hidden="true" />
-            </button>
-          </div>
-          <div className="flex items-center justify-center mx-auto rounded-full">
-            <img className="w-10 h-10 rounded-full" src={tokenList[1].logo} alt="" />
-          </div>
-          <div>
-            <div className="mt-3 text-center sm:mt-5">
-              <h3
-                className="text-lg font-medium leading-6 text-gray-900 font-headings"
-                id="modal-headline"
-              >
-                Unstake DIKO
-              </h3>
-              <p className="mt-3 text-sm text-gray-500">
-                You are currently staking{' '}
-                {microToReadable(stakedAmount).toLocaleString(undefined, {
-                  minimumFractionDigits: 2,
-                  maximumFractionDigits: 6,
-                })}{' '}
-                DIKO.
-              </p>
-              <div className="mt-6">
-                <InputAmount
-                  balance={microToReadable(stakedAmount).toLocaleString()}
-                  token="DIKO"
-                  inputName="unstakeDiko"
-                  inputId="unstakeAmount"
-                  inputValue={stakeAmount}
-                  inputLabel="Unstake DIKO"
-                  onInputChange={onInputStakeChange}
-                  onClickMax={unstakeMaxAmount}
-                />
-              </div>
-            </div>
-          </div>
-          <div className="mt-5 sm:mt-4 sm:flex sm:flex-row-reverse">
-            <button
-              type="button"
-              className="inline-flex justify-center w-full px-4 py-2 text-base font-medium text-white bg-indigo-600 border border-transparent rounded-md shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:ml-3 sm:w-auto sm:text-sm"
-              onClick={() => unstakeDiko()}
-            >
-              Unstake
-            </button>
-            <button
-              type="button"
-              className="inline-flex justify-center w-full px-4 py-2 mt-3 text-base font-medium text-gray-700 bg-white border border-gray-300 rounded-md shadow-sm hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:w-auto sm:text-sm"
-              onClick={() => setShowUnstakeModal(false)}
-            >
-              Cancel
-            </button>
-          </div>
-        </div>
+      <p className="mt-3 text-sm text-center text-gray-500">
+        You are currently staking{' '}
+        {microToReadable(stakedAmount).toLocaleString(undefined, {
+          minimumFractionDigits: 2,
+          maximumFractionDigits: 6,
+        })}{' '}
+        DIKO.
+      </p>
+      <div className="mt-6">
+        <InputAmount
+          balance={microToReadable(stakedAmount).toLocaleString()}
+          token="DIKO"
+          inputName="unstakeDiko"
+          inputId="unstakeAmount"
+          inputValue={stakeAmount}
+          inputLabel="Unstake DIKO"
+          onInputChange={onInputStakeChange}
+          onClickMax={unstakeMaxAmount}
+          ref={inputRef}
+        />
       </div>
     </Modal>
   );

--- a/web/components/unstake-diko-modal.tsx
+++ b/web/components/unstake-diko-modal.tsx
@@ -17,7 +17,6 @@ import { stacksNetwork as network } from '@common/utils';
 import { useConnect } from '@stacks/connect-react';
 import { Alert } from './ui/alert';
 
-
 export const UnstakeDikoModal = ({ showUnstakeModal, setShowUnstakeModal, stakedAmount }) => {
   const [state, setState] = useContext(AppContext);
   const [errors, setErrors] = useState<string[]>([]);

--- a/web/components/unstake-lp-modal.tsx
+++ b/web/components/unstake-lp-modal.tsx
@@ -1,6 +1,5 @@
-import React, { useContext, useState } from 'react';
+import React, { useContext, useState, useRef } from 'react';
 import { Modal } from '@blockstack/ui';
-import { XIcon } from '@heroicons/react/outline';
 import { tokenList } from '@components/token-swap-list';
 import { AppContext } from '@common/context';
 import { InputAmount } from './input-amount';
@@ -24,8 +23,9 @@ export const UnstakeLpModal = ({
   const stxAddress = useSTXAddress();
   const contractAddress = process.env.REACT_APP_CONTRACT_ADDRESS || '';
   const { doContractCall } = useConnect();
+  const inputRef = useRef<HTMLInputElement>(null);
 
-  const unstakeDiko = async () => {
+  const unstake = async () => {
     let contractName = 'arkadiko-stake-pool-diko-usda-v1-1';
     let tokenContract = 'arkadiko-swap-token-diko-usda';
     let ftContract = 'diko-usda';
@@ -83,85 +83,57 @@ export const UnstakeLpModal = ({
     setStakeAmount(value);
   };
 
-  return (
-    <Modal isOpen={showUnstakeModal}>
-      <div className="flex items-end justify-center px-4 pt-6 pb-6 text-center sm:block sm:p-0">
-        {errors.length > 0 ? (
-          <div className="mt-4">
-            <Alert type={Alert.type.ERROR}>
-              {errors.map(txt => (
-                <p key={txt}>{txt}</p>
-              ))}
-            </Alert>
-          </div>
-        ) : null}
+  const lpPairTokenX = tokenList.findIndex(obj => obj.name == tokenName.split('/').slice(0, 1));
+  const lpPairTokenY = tokenList.findIndex(obj => obj.name == tokenName.split('/').slice(1));
 
-        <div
-          className="inline-block px-2 overflow-hidden text-left align-bottom bg-white rounded-lg sm:my-8 sm:align-middle sm:max-w-sm sm:w-full sm:p-6"
-          role="dialog"
-          aria-modal="true"
-          aria-labelledby="modal-headline"
-        >
-          <div className="absolute top-0 right-0 hidden pt-4 pr-4 sm:block">
-            <button
-              type="button"
-              className="text-gray-400 bg-white rounded-md hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
-              onClick={() => setShowUnstakeModal(false)}
-            >
-              <span className="sr-only">Close</span>
-              <XIcon className="w-6 h-6" aria-hidden="true" />
-            </button>
-          </div>
-          <div className="flex items-center justify-center mx-auto rounded-full">
-            <img className="w-10 h-10 rounded-full" src={tokenList[1].logo} alt="" />
-          </div>
-          <div>
-            <div className="mt-3 text-center sm:mt-5">
-              <h3
-                className="text-lg font-medium leading-6 text-gray-900 font-headings"
-                id="modal-headline"
-              >
-                Unstake {tokenName}
-              </h3>
-              <p className="mt-3 text-sm text-gray-500">
-                You are current staking{' '}
-                {microToReadable(stakedAmount).toLocaleString(undefined, {
-                  minimumFractionDigits: 2,
-                  maximumFractionDigits: 6,
-                })}{' '}
-                {tokenName}.
-              </p>
-              <div className="mt-6">
-                <InputAmount
-                  balance={microToReadable(stakedAmount).toLocaleString()}
-                  token={tokenName}
-                  inputName={`unstakeDiko${tokenName}`}
-                  inputId={`unstakeAmount${tokenName}`}
-                  inputValue={stakeAmount}
-                  inputLabel={`Unstack ${tokenName}`}
-                  onInputChange={onInputStakeChange}
-                  onClickMax={unstakeMaxAmount}
-                />
-              </div>
-            </div>
-          </div>
-          <div className="mt-5 sm:mt-4 sm:flex sm:flex-row-reverse">
-            <button
-              type="button"
-              className="inline-flex justify-center w-full px-4 py-2 text-base font-medium text-white bg-indigo-600 border border-transparent rounded-md shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:ml-3 sm:w-auto sm:text-sm"
-              onClick={() => unstakeDiko()}
-            >
-              Unstake
-            </button>
-            <button
-              type="button"
-              className="inline-flex justify-center w-full px-4 py-2 mt-3 text-base font-medium text-gray-700 bg-white border border-gray-300 rounded-md shadow-sm hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:w-auto sm:text-sm"
-              onClick={() => setShowUnstakeModal(false)}
-            >
-              Cancel
-            </button>
-          </div>
+  return (
+    <Modal
+      open={showUnstakeModal}
+      title={`Unstake ${tokenName} LP Tokens`}
+      icon={
+        <div className="flex -space-x-2 overflow-hidden">
+          <img
+            className="inline-block w-8 h-8 rounded-full ring-2 ring-white"
+            src={tokenList[lpPairTokenX].logo}
+            alt=""
+          />
+          <img
+            className="inline-block w-8 h-8 rounded-full ring-2 ring-white"
+            src={tokenList[lpPairTokenY].logo}
+            alt=""
+          />
         </div>
+      }
+      closeModal={setShowUnstakeModal(false)}
+      buttonText="Stake"
+      buttonAction={unstake}
+      initialFocus={inputRef}
+    >
+      {errors.length > 0 ? (
+        <Alert type={Alert.type.ERROR}>
+          <p>{errors[0]}</p>
+        </Alert>
+      ) : null}
+      <p className="mt-3 text-sm text-gray-500">
+        You are current staking{' '}
+        {microToReadable(stakedAmount).toLocaleString(undefined, {
+          minimumFractionDigits: 2,
+          maximumFractionDigits: 6,
+        })}{' '}
+        {tokenName}.
+      </p>
+      <div className="mt-6">
+        <InputAmount
+          balance={microToReadable(stakedAmount).toLocaleString()}
+          token={tokenName}
+          inputName={`unstakeLp-${tokenName}`}
+          inputId={`unstakeAmount-${tokenName}`}
+          inputValue={stakeAmount}
+          inputLabel={`Unstack ${tokenName}`}
+          onInputChange={onInputStakeChange}
+          onClickMax={unstakeMaxAmount}
+          ref={inputRef}
+        />
       </div>
     </Modal>
   );

--- a/web/components/unstake-lp-modal.tsx
+++ b/web/components/unstake-lp-modal.tsx
@@ -114,7 +114,7 @@ export const UnstakeLpModal = ({
           <p>{errors[0]}</p>
         </Alert>
       ) : null}
-      <p className="mt-3 text-sm text-gray-500">
+      <p className="mt-3 text-sm text-center text-gray-500">
         You are current staking{' '}
         {microToReadable(stakedAmount).toLocaleString(undefined, {
           minimumFractionDigits: 2,

--- a/web/components/view-proposal.tsx
+++ b/web/components/view-proposal.tsx
@@ -84,7 +84,6 @@ export const ViewProposal = ({ match }) => {
       });
 
       if (data['is-open'].value == false) {
-
         // Get DIKO votes for user
         const votedDiko = await callReadOnlyFunction({
           contractAddress,
@@ -98,24 +97,24 @@ export const ViewProposal = ({ match }) => {
           senderAddress: stxAddress || '',
           network: network,
         });
-        const votedDikoResult = cvToJSON(votedDiko).value["amount"].value;
+        const votedDikoResult = cvToJSON(votedDiko).value['amount'].value;
         setDikoVoted(votedDikoResult / 1000000);
 
         // Get stDIKO votes for user
         const votedStdiko = await callReadOnlyFunction({
-        contractAddress,
-        contractName: 'arkadiko-governance-v1-1',
-        functionName: 'get-tokens-by-member-by-id',
-        functionArgs: [
-          uintCV(match.params.id),
-          standardPrincipalCV(stxAddress || ''),
-          contractPrincipalCV(contractAddress, 'stdiko-token'),
-        ],
-        senderAddress: stxAddress || '',
-        network: network,
-      });
-      const votedStdikoResult = cvToJSON(votedStdiko).value["amount"].value;
-      setStdikoVoted(votedStdikoResult / 1000000);
+          contractAddress,
+          contractName: 'arkadiko-governance-v1-1',
+          functionName: 'get-tokens-by-member-by-id',
+          functionArgs: [
+            uintCV(match.params.id),
+            standardPrincipalCV(stxAddress || ''),
+            contractPrincipalCV(contractAddress, 'stdiko-token'),
+          ],
+          senderAddress: stxAddress || '',
+          network: network,
+        });
+        const votedStdikoResult = cvToJSON(votedStdiko).value['amount'].value;
+        setStdikoVoted(votedStdikoResult / 1000000);
       }
 
       setIsLoading(false);
@@ -695,7 +694,7 @@ export const ViewProposal = ({ match }) => {
                       Claim {dikoVoted} DIKO
                     </button>
                   ) : null}
-  
+
                   {dikoVoted != 0 && stdikoVoted != 0 ? (
                     <span className="text-xs font-semibold text-center uppercase">— or —</span>
                   ) : null}
@@ -709,7 +708,6 @@ export const ViewProposal = ({ match }) => {
                       Claim {stdikoVoted} stDIKO
                     </button>
                   ) : null}
-
                 </>
               )}
             </div>


### PR DESCRIPTION
Remove the modal import from `@blockstack/ui` and use our own modal component from `Headless UI` (https://headlessui.dev/react/dialog).

#### Preview

<img width="1029" alt="Screen Shot 2021-11-10 at 1 04 16 PM" src="https://user-images.githubusercontent.com/1909957/141375696-faf1aa9a-686b-426f-83eb-adc2a05ad1f9.png">

There are still 6 occurrences of the previous modal. We can replace them in another PR.

- 2 in `view-proposal.tsx`: still not sure how to handle the UI since they have 3 buttons instead of 2, I'll give it some thought;
- 4 in `manage-vault.tsx`: IMO, they should be extracted to their own component like we did for `stake-diko`, `unstake-diko`, `stake-lp`, `unstake-lp` modals.
