### PR TITLE
tweak: display all actions in stake DIKO dropdown

### DIFF
--- a/web/components/stake-lp-modal.tsx
+++ b/web/components/stake-lp-modal.tsx
@@ -137,7 +137,7 @@ export const StakeLpModal = ({
       ) : null}
 
       <p className="mt-3 text-sm text-center text-gray-500">
-        Stake your {tokenName} LP tokens at {apy}% (estimated APY) and start earning rewards now.
+        Stake your {tokenName} LP tokens at {apy}% (estimated APR) and start earning rewards now.
       </p>
       <div className="mt-6">
         <InputAmount

--- a/web/components/stake-lp-row.tsx
+++ b/web/components/stake-lp-row.tsx
@@ -176,7 +176,7 @@ export const StakeLpRow: React.FC<StakeLpRowProps> = ({
               </Disclosure.Button>
             </td>
           </tr>
-          <Disclosure.Panel as="tr">
+          <Disclosure.Panel as="tr" className="bg-gray-50">
             <td className="px-6 py-4 text-sm whitespace-nowrap">
               <RouterLink
                 to={getLpRoute}
@@ -196,7 +196,7 @@ export const StakeLpRow: React.FC<StakeLpRowProps> = ({
               ) : (
                 <button
                   type="button"
-                  className="inline-flex items-center px-4 py-2 text-sm leading-4 text-white bg-indigo-600 border border-transparent rounded-md shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 disabled:bg-gray-100 disabled:text-gray-400 disabled:cursor-not-allowed"
+                  className="inline-flex items-center px-4 py-2 text-sm leading-4 text-white bg-indigo-600 border border-transparent rounded-md shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 disabled:bg-gray-200 disabled:text-gray-500 disabled:cursor-not-allowed"
                   disabled={balance == 0}
                   onClick={() => setShowStakeLpModal(true)}
                 >

--- a/web/components/stake.tsx
+++ b/web/components/stake.tsx
@@ -33,6 +33,7 @@ import {
 } from '@heroicons/react/solid';
 import { Placeholder } from './ui/placeholder';
 import { Tooltip } from '@blockstack/ui';
+import Tippy from '@tippyjs/react';
 import { Alert } from './ui/alert';
 
 export const Stake = () => {
@@ -733,7 +734,10 @@ export const Stake = () => {
                     rel="noopener noreferrer"
                   >
                     More on the Security Module
-                    <ExternalLinkIcon className="flex-shrink-0 block w-3 h-3 ml-2" aria-hidden="true" />
+                    <ExternalLinkIcon
+                      className="flex-shrink-0 block w-3 h-3 ml-2"
+                      aria-hidden="true"
+                    />
                   </a>
                 </div>
               </header>
@@ -821,98 +825,167 @@ export const Stake = () => {
                       )}
                     </div>
                     <div className="self-center">
-                      {state.balance['diko'] > 0 ||
-                      state.balance['stdiko'] > 0 ||
-                      (stakedAmount && canUnstake) ? (
-                        <Menu as="div" className="relative flex items-center justify-end">
-                          {({ open }) => (
-                            <>
-                              <Menu.Button className="inline-flex items-center justify-center text-sm text-indigo-500 bg-white rounded-lg focus:outline-none focus-visible:ring focus-visible:ring-indigo-500 focus-visible:ring-opacity-75">
-                                <span>Actions</span>
-                                <ChevronUpIcon
-                                  className={`${
-                                    open
-                                      ? ''
-                                      : 'transform rotate-180 transition ease-in-out duration-300'
-                                  } ml-2 w-5 h-5 text-indigo-500`}
-                                />
-                              </Menu.Button>
-                              <Transition
-                                show={open}
-                                as={Fragment}
-                                enter="transition ease-out duration-100"
-                                enterFrom="transform opacity-0 scale-95"
-                                enterTo="transform opacity-100 scale-100"
-                                leave="transition ease-in duration-75"
-                                leaveFrom="transform opacity-100 scale-100"
-                                leaveTo="transform opacity-0 scale-95"
+                      <Menu as="div" className="relative flex items-center justify-end">
+                        {({ open }) => (
+                          <>
+                            <Menu.Button className="inline-flex items-center justify-center text-sm text-indigo-500 bg-white rounded-lg focus:outline-none focus-visible:ring focus-visible:ring-indigo-500 focus-visible:ring-opacity-75">
+                              <span>Actions</span>
+                              <ChevronUpIcon
+                                className={`${
+                                  open
+                                    ? ''
+                                    : 'transform rotate-180 transition ease-in-out duration-300'
+                                } ml-2 w-5 h-5 text-indigo-500`}
+                              />
+                            </Menu.Button>
+                            <Transition
+                              show={open}
+                              as={Fragment}
+                              enter="transition ease-out duration-100"
+                              enterFrom="transform opacity-0 scale-95"
+                              enterTo="transform opacity-100 scale-100"
+                              leave="transition ease-in duration-75"
+                              leaveFrom="transform opacity-100 scale-100"
+                              leaveTo="transform opacity-0 scale-95"
+                            >
+                              <Menu.Items
+                                static
+                                className="absolute top-0 z-10 w-48 mx-3 mt-6 origin-top-right bg-white divide-y divide-gray-200 rounded-md shadow-lg right-3 ring-1 ring-black ring-opacity-5 focus:outline-none"
                               >
-                                <Menu.Items
-                                  static
-                                  className="absolute top-0 z-10 w-48 mx-3 mt-6 origin-top-right bg-white divide-y divide-gray-200 rounded-md shadow-lg right-3 ring-1 ring-black ring-opacity-5 focus:outline-none"
-                                >
-                                  <div className="px-1 py-1">
-                                    {state.balance['diko'] > 0 ? (
-                                      <Menu.Item>
-                                        {({ active }) => (
-                                          <button
-                                            className={`${
-                                              active ? 'bg-indigo-500 text-white' : 'text-gray-900'
-                                            } group flex rounded-md items-center w-full px-2 py-2 text-sm`}
-                                            onClick={() => setShowStakeModal(true)}
+                                <div className="px-1 py-1">
+                                  <Menu.Item>
+                                    {({ active }) => (
+                                      <button
+                                        className={`${
+                                          active
+                                            ? 'bg-indigo-500 text-white disabled:bg-gray-400 disabled:cursor-not-allowed'
+                                            : 'text-gray-900'
+                                        } group flex rounded-md items-center w-full px-2 py-2 text-sm`}
+                                        disabled={!(state.balance['diko'] > 0)}
+                                        onClick={() => setShowStakeModal(true)}
+                                      >
+                                        {!(state.balance['diko'] > 0) ? (
+                                          <Tooltip
+                                            placement="left"
+                                            className="mr-2"
+                                            label={`You don't have any DIKO to stake.`}
                                           >
+                                            <div className="flex items-center w-full">
+                                              <ArrowCircleDownIcon
+                                                className="w-5 h-5 mr-3 text-gray-400 group-hover:text-white"
+                                                aria-hidden="true"
+                                              />
+                                              Stake
+                                            </div>
+                                          </Tooltip>
+                                        ) : (
+                                          <>
                                             <ArrowCircleDownIcon
                                               className="w-5 h-5 mr-3 text-gray-400 group-hover:text-white"
                                               aria-hidden="true"
                                             />
                                             Stake
-                                          </button>
+                                          </>
                                         )}
-                                      </Menu.Item>
-                                    ) : null}
-                                    {state.balance['stdiko'] > 0 && !cooldownRunning ? (
-                                      <Menu.Item>
-                                        {({ active }) => (
-                                          <button
-                                            className={`${
-                                              active ? 'bg-indigo-500 text-white' : 'text-gray-900'
-                                            } group flex rounded-md items-center w-full px-2 py-2 text-sm`}
-                                            onClick={() => startDikoCooldown()}
+                                      </button>
+                                    )}
+                                  </Menu.Item>
+
+                                  <Menu.Item>
+                                    {({ active }) => (
+                                      <button
+                                        className={`${
+                                          active
+                                            ? 'bg-indigo-500 text-white disabled:bg-gray-400 disabled:cursor-not-allowed'
+                                            : 'text-gray-900'
+                                        } group flex rounded-md items-center w-full px-2 py-2 text-sm`}
+                                        onClick={() => setShowUnstakeModal(true)}
+                                        disabled={!(stakedAmount > 0 && canUnstake)}
+                                      >
+                                        {!(stakedAmount > 0) ? (
+                                          <Tooltip
+                                            placement="left"
+                                            className="mr-2"
+                                            label={`You don't have any staked DIKO.`}
                                           >
-                                            <ClockIcon
-                                              className="w-5 h-5 mr-3 text-gray-400 group-hover:text-white"
-                                              aria-hidden="true"
-                                            />
-                                            Start cooldown
-                                          </button>
-                                        )}
-                                      </Menu.Item>
-                                    ) : null}
-                                    {stakedAmount && canUnstake ? (
-                                      <Menu.Item>
-                                        {({ active }) => (
-                                          <button
-                                            className={`${
-                                              active ? 'bg-indigo-500 text-white' : 'text-gray-900'
-                                            } group flex rounded-md items-center w-full px-2 py-2 text-sm`}
-                                            onClick={() => setShowUnstakeModal(true)}
+                                            <div className="flex items-center w-full">
+                                              <ArrowCircleUpIcon
+                                                className="w-5 h-5 mr-3 text-gray-400 group-hover:text-white"
+                                                aria-hidden="true"
+                                              />
+                                              Unstake
+                                            </div>
+                                          </Tooltip>
+                                        ) : !canUnstake ? (
+                                          <Tooltip
+                                            placement="left"
+                                            className="mr-2"
+                                            label={`Either you haven't started the cooldown period, or the cooldown timer hasn't ended yet.`}
                                           >
+                                            <div className="flex items-center w-full">
+                                              <ArrowCircleUpIcon
+                                                className="w-5 h-5 mr-3 text-gray-400 group-hover:text-white"
+                                                aria-hidden="true"
+                                              />
+                                              Unstake
+                                            </div>
+                                          </Tooltip>
+                                        ) : (
+                                          <>
                                             <ArrowCircleUpIcon
                                               className="w-5 h-5 mr-3 text-gray-400 group-hover:text-white"
                                               aria-hidden="true"
                                             />
                                             Unstake
-                                          </button>
+                                          </>
                                         )}
-                                      </Menu.Item>
-                                    ) : null}
-                                  </div>
-                                </Menu.Items>
-                              </Transition>
-                            </>
-                          )}
-                        </Menu>
-                      ) : null}
+                                      </button>
+                                    )}
+                                  </Menu.Item>
+
+                                  <Menu.Item>
+                                    {({ active }) => (
+                                      <button
+                                        className={`${
+                                          active
+                                            ? 'bg-indigo-500 text-white disabled:bg-gray-400 disabled:cursor-not-allowed'
+                                            : 'text-gray-900'
+                                        } group flex rounded-md items-center w-full px-2 py-2 text-sm`}
+                                        onClick={() => startDikoCooldown()}
+                                        disabled={cooldownRunning}
+                                      >
+                                        {cooldownRunning ? (
+                                          <Tooltip
+                                            placement="left"
+                                            className="mr-2"
+                                            label={`Cooldown is already in progress.`}
+                                          >
+                                            <div className="flex items-center w-full">
+                                              <ClockIcon
+                                                className="w-5 h-5 mr-3 text-gray-400 group-hover:text-white"
+                                                aria-hidden="true"
+                                              />
+                                              Start cooldown
+                                            </div>
+                                          </Tooltip>
+                                        ) : (
+                                          <>
+                                            <ClockIcon
+                                              className="w-5 h-5 mr-3 text-gray-400 group-hover:text-white"
+                                              aria-hidden="true"
+                                            />
+                                            Start cooldown
+                                          </>
+                                        )}
+                                      </button>
+                                    )}
+                                  </Menu.Item>
+                                </div>
+                              </Menu.Items>
+                            </Transition>
+                          </>
+                        )}
+                      </Menu>
                     </div>
                   </div>
                 </div>

--- a/web/components/stake.tsx
+++ b/web/components/stake.tsx
@@ -868,7 +868,7 @@ export const Stake = () => {
                                           <Tooltip
                                             placement="left"
                                             className="mr-2"
-                                            label={`You don't have any DIKO to stake.`}
+                                            label={`You don't have any available DIKO to stake in your wallet.`}
                                           >
                                             <div className="flex items-center w-full">
                                               <ArrowCircleDownIcon


### PR DESCRIPTION
When actions aren't available, give some information as to why.

### Can't start cooldown if already in progress
![Screen Shot 2021-12-03 at 11 09 43 AM](https://user-images.githubusercontent.com/1909957/144593382-88884552-87d2-4a3a-aff8-55050502c83b.png)

### Can't unstake if you don't have staked DIKO
![Screen Shot 2021-12-03 at 11 09 16 AM](https://user-images.githubusercontent.com/1909957/144593387-783c5c3c-4b29-4057-be00-0f3398ce48b8.png)

### Can't stake if no available DIKO in wallet
![Screen Shot 2021-12-03 at 11 08 39 AM](https://user-images.githubusercontent.com/1909957/144593388-e8a42516-d0f5-4343-80cf-b0c16d91487a.png)

### Can't unstake if cooldown period hasn't started or is not over
![Screen Shot 2021-12-03 at 11 07 53 AM](https://user-images.githubusercontent.com/1909957/144593390-9b48b8cc-85e5-4cc5-8442-b2f125bf2a78.png)

Again, feel free to update copy if you don't like it.
