### PR TITLE
tweak: improve dark mode depth

### DIFF
--- a/analytics-web/components/market-cap.tsx
+++ b/analytics-web/components/market-cap.tsx
@@ -72,8 +72,8 @@ export const MarketCap: React.FC = ({ lastDikoPrice, lastUsdaPrice }) => {
       </header>
 
       <div className="min-w-full mt-4 overflow-hidden overflow-x-auto align-middle border border-gray-200 rounded-lg dark:border-zinc-600 lg:hidden">
-        <div className="bg-white dark:bg-zinc-900">
-          <div className="mx-auto bg-white dark:bg-zinc-900 sm:py-6 max-w-7xl">
+        <div className="bg-white dark:bg-zinc-800">
+          <div className="mx-auto bg-white dark:bg-zinc-800 sm:py-6 max-w-7xl">
             <div className="max-w-2xl mx-auto space-y-2 divide-y divide-gray-200 dark:divide-zinc-600">
               {tokens.map(token => (
                 <section className="pt-6" key={token.name}>

--- a/analytics-web/components/prices.tsx
+++ b/analytics-web/components/prices.tsx
@@ -97,8 +97,8 @@ export const Prices: React.FC = () => {
       </header>
 
       <div className="min-w-full mt-4 overflow-hidden overflow-x-auto align-middle border border-gray-200 rounded-lg dark:border-zinc-600 lg:hidden">
-        <div className="bg-white dark:bg-zinc-900">
-          <div className="mx-auto bg-white dark:bg-zinc-900 sm:py-6 max-w-7xl">
+        <div className="bg-white dark:bg-zinc-800">
+          <div className="mx-auto bg-white dark:bg-zinc-800 sm:py-6 max-w-7xl">
             <div className="max-w-2xl mx-auto space-y-2 divide-y divide-gray-200 dark:divide-zinc-600">
               {assets.map(asset => (
                 <section className="pt-4" key={asset.token}>
@@ -181,7 +181,7 @@ export const Prices: React.FC = () => {
           <div className="inline-block min-w-full py-2 align-middle sm:px-6 lg:px-8">
             <div className="overflow-hidden border border-gray-200 rounded-lg dark:border-zinc-700">
               <table className="min-w-full divide-y divide-gray-200 dark:divide-zinc-600">
-                <thead className="bg-gray-50 dark:bg-zinc-900 dark:bg-opacity-80">
+                <thead className="bg-gray-50 dark:bg-zinc-800 dark:bg-opacity-80">
                   <tr>
                     <th
                       scope="col"
@@ -203,9 +203,9 @@ export const Prices: React.FC = () => {
                     </th>
                   </tr>
                 </thead>
-                <tbody className="bg-white divide-y divide-gray-200 dark:bg-zinc-900 dark:divide-zinc-600">
+                <tbody className="bg-white divide-y divide-gray-200 dark:bg-zinc-800 dark:divide-zinc-600">
                   {assets.map(asset => (
-                    <tr key={asset.token} className="bg-white dark:bg-zinc-900">
+                    <tr key={asset.token} className="bg-white dark:bg-zinc-800">
                       <td className="px-6 py-4 text-sm text-gray-900 dark:text-zinc-100 whitespace-nowrap">
                         <div className="flex items-center">
                           <div className="w-10 h-10 shrink-0">

--- a/web/components/add-swap-liquidity.tsx
+++ b/web/components/add-swap-liquidity.tsx
@@ -363,7 +363,7 @@ export const AddSwapLiquidity: React.FC = ({ match }) => {
                 </span>
               </RouterLink>
             </p>
-            <div className="relative z-10 w-full max-w-lg bg-white rounded-lg shadow dark:bg-zinc-900">
+            <div className="relative z-10 w-full max-w-lg bg-white rounded-lg shadow dark:bg-zinc-800">
               <div className="flex flex-col p-4">
                 <div className="flex justify-between mb-4">
                   <div>
@@ -410,7 +410,7 @@ export const AddSwapLiquidity: React.FC = ({ match }) => {
                 <form className="mt-4">
                   {isLoading ? (
                     <>
-                      <div className="border border-gray-200 rounded-md shadow-sm bg-gray-50 hover:border-gray-300 focus-within:border-indigo-200 dark:border-zinc-600 dark:bg-zinc-800 dark:hover:border-zinc-900 dark:focus-within:border-indigo-200 h-[104px]">
+                      <div className="border border-gray-200 rounded-md shadow-sm bg-gray-50 hover:border-gray-300 focus-within:border-indigo-200 dark:border-zinc-600 dark:bg-zinc-900 dark:hover:border-zinc-900 dark:focus-within:border-indigo-200 h-[104px]">
                         <div className="flex items-center p-4 pb-2">
                           <TokenSwapList selected={tokenX} disabled={true} />
                         </div>
@@ -427,7 +427,7 @@ export const AddSwapLiquidity: React.FC = ({ match }) => {
                         <PlusIcon className="w-6 h-6 text-gray-500" aria-hidden="true" />
                       </div>
 
-                      <div className="mt-1 border border-gray-200 rounded-md shadow-sm bg-gray-50 hover:border-gray-300 focus-within:border-indigo-200 dark:border-zinc-600 dark:bg-zinc-800 dark:hover:border-zinc-900 dark:focus-within:border-indigo-200 h-[104px]">
+                      <div className="mt-1 border border-gray-200 rounded-md shadow-sm bg-gray-50 hover:border-gray-300 focus-within:border-indigo-200 dark:border-zinc-600 dark:bg-zinc-900 dark:hover:border-zinc-900 dark:focus-within:border-indigo-200 h-[104px]">
                         <div className="flex items-center p-4 pb-2">
                           <TokenSwapList selected={tokenY} disabled={true} />
                         </div>
@@ -442,7 +442,7 @@ export const AddSwapLiquidity: React.FC = ({ match }) => {
                     </>
                   ) : (
                     <>
-                      <div className="border border-gray-200 rounded-md shadow-sm bg-gray-50 hover:border-gray-300 focus-within:border-indigo-200 dark:border-zinc-600 dark:bg-zinc-800 dark:hover:border-zinc-900 dark:focus-within:border-indigo-200">
+                      <div className="border border-gray-200 rounded-md shadow-sm bg-gray-50 hover:border-gray-300 focus-within:border-indigo-200 dark:border-zinc-600 dark:bg-zinc-900 dark:hover:border-zinc-900 dark:focus-within:border-indigo-200">
                         <div className="flex items-center p-4 pb-2">
                           <TokenSwapList
                             selected={tokenX}
@@ -466,7 +466,7 @@ export const AddSwapLiquidity: React.FC = ({ match }) => {
                             value={tokenXAmount || ''}
                             onChange={onInputXChange}
                             min={0}
-                            className="flex-1 p-0 m-0 text-xl font-semibold text-right truncate border-0 focus:outline-none focus:ring-0 bg-gray-50 dark:bg-zinc-800 dark:text-zinc-50"
+                            className="flex-1 p-0 m-0 text-xl font-semibold text-right truncate border-0 focus:outline-none focus:ring-0 bg-gray-50 dark:bg-zinc-900 dark:text-zinc-50"
                             style={{ appearance: 'textfield' }}
                           />
                         </div>
@@ -502,7 +502,7 @@ export const AddSwapLiquidity: React.FC = ({ match }) => {
                         <PlusIcon className="w-6 h-6 text-gray-500" aria-hidden="true" />
                       </div>
 
-                      <div className="border border-gray-200 rounded-md shadow-sm bg-gray-50 hover:border-gray-300 focus-within:border-indigo-200 dark:border-zinc-600 dark:bg-zinc-800 dark:hover:border-zinc-900 dark:focus-within:border-indigo-200">
+                      <div className="border border-gray-200 rounded-md shadow-sm bg-gray-50 hover:border-gray-300 focus-within:border-indigo-200 dark:border-zinc-600 dark:bg-zinc-900 dark:hover:border-zinc-900 dark:focus-within:border-indigo-200">
                         <div className="flex items-center p-4 pb-2">
                           <TokenSwapList
                             selected={tokenY}
@@ -526,7 +526,7 @@ export const AddSwapLiquidity: React.FC = ({ match }) => {
                             value={tokenYAmount || ''}
                             onChange={onInputYChange}
                             min={0}
-                            className="flex-1 p-0 m-0 text-xl font-semibold text-right truncate border-0 focus:outline-none focus:ring-0 bg-gray-50 dark:bg-zinc-800 dark:text-zinc-50"
+                            className="flex-1 p-0 m-0 text-xl font-semibold text-right truncate border-0 focus:outline-none focus:ring-0 bg-gray-50 dark:bg-zinc-900 dark:text-zinc-50"
                             style={{ appearance: 'textfield' }}
                           />
                         </div>

--- a/web/components/app.tsx
+++ b/web/components/app.tsx
@@ -241,7 +241,7 @@ export const App: React.FC = () => {
             titleTemplate="Arkadiko Finance App - %s"
             defaultTitle="Arkadiko Finance App"
           />
-          <div className="flex flex-col font-sans bg-white dark:bg-zinc-800 min-height-screen">
+          <div className="flex flex-col font-sans bg-white dark:bg-zinc-900 min-height-screen">
             {location.pathname.indexOf('/onboarding') != 0 ? (
               <Header signOut={signOut} setShowSidebar={setShowSidebar} />
             ) : null}

--- a/web/components/auction-group.tsx
+++ b/web/components/auction-group.tsx
@@ -149,7 +149,7 @@ export const AuctionGroup: React.FC<AuctionProps[]> = ({ auctions, stacksTipHeig
       <div className="flex flex-col mt-2">
         <div className="min-w-full overflow-hidden overflow-x-auto align-middle shadow sm:rounded-lg">
           <table className="min-w-full divide-y divide-gray-200 dark:divide-zinc-600">
-            <thead className="bg-gray-50 dark:bg-zinc-900 dark:bg-opacity-80">
+            <thead className="bg-gray-50 dark:bg-zinc-800 dark:bg-opacity-80">
               <tr>
                 <th className="px-6 py-3 text-xs font-medium tracking-wider text-left text-gray-500 uppercase dark:text-zinc-400">
                   Auction ID
@@ -173,7 +173,7 @@ export const AuctionGroup: React.FC<AuctionProps[]> = ({ auctions, stacksTipHeig
                 <th className="px-6 py-3 text-xs font-medium tracking-wider text-left text-gray-500 uppercase dark:text-zinc-400"></th>
               </tr>
             </thead>
-            <tbody className="bg-white divide-y divide-gray-200 dark:bg-zinc-900 dark:divide-zinc-600">{auctionItems}</tbody>
+            <tbody className="bg-white divide-y divide-gray-200 dark:bg-zinc-800 dark:divide-zinc-600">{auctionItems}</tbody>
           </table>
         </div>
       </div>

--- a/web/components/auction.tsx
+++ b/web/components/auction.tsx
@@ -104,7 +104,7 @@ export const Auction: React.FC<AuctionProps> = ({
   };
 
   return (
-    <tr className="bg-white dark:bg-zinc-900">
+    <tr className="bg-white dark:bg-zinc-800">
       <td className="px-6 py-4 text-sm text-left text-gray-500 whitespace-nowrap">
         <span className="font-medium text-gray-900 dark:text-zinc-100">
           {id}.{lotId + 1}

--- a/web/components/collateral-type.tsx
+++ b/web/components/collateral-type.tsx
@@ -28,8 +28,8 @@ export const CollateralType: React.FC<CollateralTypeProps> = ({ types, setStep }
 
   return (
     <div className="min-w-full overflow-hidden overflow-x-auto align-middle border border-gray-200 rounded-lg dark:border-zinc-600">
-      <div className="bg-white dark:bg-zinc-900">
-        <div className="py-12 mx-auto bg-white dark:bg-zinc-900 sm:py-6 max-w-7xl">
+      <div className="bg-white dark:bg-zinc-800">
+        <div className="py-12 mx-auto bg-white dark:bg-zinc-800 sm:py-6 max-w-7xl">
           {/* xs to lg */}
           <div className="max-w-2xl mx-auto space-y-16 lg:hidden">
             {collateralItems.map((collateral, collateralIdx) => (

--- a/web/components/create-vault-confirm.tsx
+++ b/web/components/create-vault-confirm.tsx
@@ -66,7 +66,7 @@ export const CreateVaultConfirm = ({ setStep, coinAmounts, setCoinAmounts }) => 
         </header>
 
         <div className="max-w-4xl mx-auto mt-4 shadow sm:rounded-md sm:overflow-hidden">
-          <div className="px-4 py-5 space-y-6 bg-white dark:bg-zinc-900 sm:p-6">
+          <div className="px-4 py-5 space-y-6 bg-white dark:bg-zinc-800 sm:p-6">
             {tokenName.includes('STX') ? (
               <div>
                 <div className="flex items-center">
@@ -139,7 +139,7 @@ export const CreateVaultConfirm = ({ setStep, coinAmounts, setCoinAmounts }) => 
         </div>
 
         <div className="max-w-4xl mx-auto mt-4 shadow sm:rounded-md sm:overflow-hidden">
-          <div className="px-4 py-5 space-y-6 bg-white dark:bg-zinc-900 sm:p-6">
+          <div className="px-4 py-5 space-y-6 bg-white dark:bg-zinc-800 sm:p-6">
             <div className="space-y-8 divide-y divide-gray-200 dark:divide-zinc-600">
               <div className="space-y-4 divide-y divide-gray-100 dark:divide-gray-800">
                 <div className="sm:flex sm:justify-between sm:items-baseline">

--- a/web/components/create-vault-step-one.tsx
+++ b/web/components/create-vault-step-one.tsx
@@ -41,7 +41,7 @@ export const CreateVaultStepOne: React.FC<VaultProps> = ({ setStep }) => {
           <div className="flex items-center justify-center mb-6">
             <button
               type="button"
-              className={`w-1/2 p-6 text-lg font-semibold text-center text-gray-500 bg-white rounded-md shadow md:w-1/6 hover:bg-white/80 ${collateralTypeChoice === 'stx' ? 'border border-indigo-500/60' : 'border border-transparent'}`}
+              className={`w-1/2 p-6 text-lg font-semibold text-center text-gray-500 dark:text-zinc-300 bg-white dark:bg-zinc-700 rounded-md shadow md:w-1/6 hover:bg-white/80 ${collateralTypeChoice === 'stx' ? 'border border-indigo-500/60' : 'border border-transparent'}`}
               onClick={() => setCollateralTypeChoice('stx')}
             >
               <img className="w-10 h-10 mx-auto mb-3 rounded-full" src={tokenList[2].logo} alt="" />
@@ -50,7 +50,7 @@ export const CreateVaultStepOne: React.FC<VaultProps> = ({ setStep }) => {
 
             <button
               type="button"
-              className={`w-1/2 p-6 ml-6 text-lg font-semibold text-center text-gray-500 bg-white rounded-md shadow md:w-1/6 hover:bg-white/80 ${collateralTypeChoice === 'xbtc' ? 'border border-indigo-500/60' : 'border border-transparent'}`}
+              className={`w-1/2 p-6 ml-6 text-lg font-semibold text-center text-gray-500 dark:text-zinc-300 bg-white dark:bg-zinc-700 rounded-md shadow md:w-1/6 hover:bg-white/80 ${collateralTypeChoice === 'xbtc' ? 'border border-indigo-500/60' : 'border border-transparent'}`}
               onClick={() => setCollateralTypeChoice('xbtc')}
             >
               <img className="w-10 h-10 mx-auto mb-3 rounded-full" src={tokenList[3].logo} alt="" />

--- a/web/components/create-vault-step-two.tsx
+++ b/web/components/create-vault-step-two.tsx
@@ -197,7 +197,7 @@ export const CreateVaultStepTwo: React.FC<VaultProps> = ({ setStep, setCoinAmoun
         </header>
 
         <div className="mt-4 shadow sm:rounded-md sm:overflow-hidden">
-          <div className="px-4 py-5 space-y-6 bg-white dark:bg-zinc-900 sm:p-6">
+          <div className="px-4 py-5 space-y-6 bg-white dark:bg-zinc-800 sm:p-6">
             {errors.length > 0 ? (
               <Alert type={Alert.type.ERROR}>
                 {errors.map(txt => (

--- a/web/components/footer.tsx
+++ b/web/components/footer.tsx
@@ -4,7 +4,7 @@ import { TrendingUpIcon } from '@heroicons/react/outline';
 export const Footer = () => {
   return (
     <footer>
-      <div className="px-6 py-4 mx-auto bg-gray-100 lg:px-8 dark:bg-zinc-800">
+      <div className="px-6 py-4 mx-auto bg-gray-100 lg:px-8 dark:bg-zinc-900">
         <div className="md:flex md:items-center md:justify-between">
           <a href="https://info.arkadiko.finance/" target="_blank" rel="noopener noreferrer" className="relative flex items-center group">
             <TrendingUpIcon

--- a/web/components/governance.tsx
+++ b/web/components/governance.tsx
@@ -174,7 +174,7 @@ export const Governance = () => {
               </header>
 
               {isLoading ? (
-                <div className="mt-5 overflow-hidden bg-white rounded-md shadow dark:bg-zinc-900">
+                <div className="mt-5 overflow-hidden bg-white rounded-md shadow dark:bg-zinc-800">
                   <div className="px-4 py-4 sm:px-6">
                     <div className="flex items-center justify-between">
                       <Placeholder className="py-2" width={Placeholder.width.HALF} />

--- a/web/components/header.tsx
+++ b/web/components/header.tsx
@@ -40,7 +40,7 @@ export const Header: React.FC<HeaderProps> = ({ signOut, setShowSidebar }) => {
                 <RouterLink className="flex items-center shrink-0" to="/">
                   <svg className="w-auto h-6 lg:block sm:h-8 text-zinc-900 dark:text-white" viewBox="0 0 60 46" xmlns="http://www.w3.org/2000/svg"><path fillRule="evenodd" clipRule="evenodd" d="M19.03 1.54A2.68 2.68 0 0121.46 0h11.48c.95 0 1.82.49 2.3 1.29L59.62 41.6c.5.82.5 1.84.03 2.66a2.69 2.69 0 01-2.33 1.34h-12a2.7 2.7 0 01-1.9-.77 31.32 31.32 0 00-16.15-8.17c-6.8-1.09-14.81.4-22.7 8.17a2.71 2.71 0 01-3.42.3 2.62 2.62 0 01-.9-3.28L19.02 1.54zm7.1 3.75L46.86 40.3h5.74L31.42 5.3h-5.29zm10.89 28.89L21.75 8.37 9.55 34.55a29.17 29.17 0 0118.58-3.1c3.2.5 6.2 1.5 8.89 2.73z" fill="currentColor"/></svg>
 
-                  <span className="inline-block ml-2 text-lg font-bold align-middle font-headings dark:text-zinc-100">
+                  <span className="inline-block ml-2 text-lg font-bold align-middle font-headings text-zinc-900 dark:text-zinc-100">
                     Arkadiko
                   </span>
                 </RouterLink>

--- a/web/components/home.tsx
+++ b/web/components/home.tsx
@@ -6,7 +6,7 @@ export interface ContainerProps {}
 
 export const Container: React.FC<ContainerProps> = ({ children, ...props }) => {
   return (
-    <div className="w-full min-h-screen bg-gray-100 dark:bg-zinc-800" {...props}>
+    <div className="w-full min-h-screen bg-gray-100 dark:bg-zinc-900" {...props}>
       <div className="px-6 mx-auto max-w-7xl lg:px-8">{children}</div>
     </div>
   );
@@ -22,7 +22,7 @@ export const Home: React.FC = () => {
           <Mint />
         </Container>
       ) : (
-        <div className="w-full min-h-screen overflow-hidden bg-gray-100 dark:bg-zinc-800">
+        <div className="w-full min-h-screen overflow-hidden bg-gray-100 dark:bg-zinc-900">
           <div className="px-6 mx-auto lg:px-8 sm:pb-12">
             <main className="pt-12 pb-12 sm:pt-0">
               <div className="relative max-w-[554px] mx-auto">

--- a/web/components/lot-group.tsx
+++ b/web/components/lot-group.tsx
@@ -25,7 +25,7 @@ export const LotGroup: React.FC<LotProps[]> = ({ lots }) => {
     <div className="flex flex-col mt-4">
       <div className="min-w-full overflow-hidden overflow-x-auto align-middle shadow sm:rounded-lg">
         <table className="min-w-full divide-y divide-gray-200 dark:divide-zinc-600">
-          <thead className="bg-gray-50 dark:bg-zinc-900 dark:bg-opacity-80">
+          <thead className="bg-gray-50 dark:bg-zinc-800 dark:bg-opacity-80">
             <tr>
               <th className="px-6 py-3 text-xs font-medium tracking-wider text-left text-gray-500 uppercase dark:text-zinc-400">
                 Auction ID
@@ -39,7 +39,7 @@ export const LotGroup: React.FC<LotProps[]> = ({ lots }) => {
               <th className="px-6 py-3 text-xs font-medium tracking-wider text-left text-gray-500 uppercase dark:text-zinc-400"></th>
             </tr>
           </thead>
-          <tbody className="bg-white divide-y divide-gray-200 dark:bg-zinc-900 dark:divide-zinc-600">{lotItems}</tbody>
+          <tbody className="bg-white divide-y divide-gray-200 dark:bg-zinc-800 dark:divide-zinc-600">{lotItems}</tbody>
         </table>
       </div>
     </div>

--- a/web/components/lot.tsx
+++ b/web/components/lot.tsx
@@ -56,7 +56,7 @@ export const Lot: React.FC<LotProps> = ({ id, lotId, collateralAmount, collatera
   }, [state.currentTxStatus]);
 
   return (
-    <tr className="bg-white dark:bg-zinc-900">
+    <tr className="bg-white dark:bg-zinc-800">
       <td className="px-6 py-4 text-sm text-left text-gray-500 whitespace-nowrap">
         <span className="font-medium text-gray-900 dark:text-zinc-100">
           {id}.{lotId + 1}

--- a/web/components/manage-vault.tsx
+++ b/web/components/manage-vault.tsx
@@ -570,7 +570,7 @@ export const ManageVault = ({ match }) => {
 
           <div className="mt-4" id="liquidation-status-alert">
             <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
-              <div className="flex flex-col bg-white divide-y divide-gray-200 rounded-md shadow dark:bg-zinc-900 dark:divide-zinc-600">
+              <div className="flex flex-col bg-white divide-y divide-gray-200 rounded-md shadow dark:bg-zinc-800 dark:divide-zinc-600">
                 <div className="px-4 py-3">
                   <h3 className="text-base font-normal leading-6 text-gray-900 font-headings dark:text-zinc-50">Vault details</h3>
                 </div>
@@ -684,7 +684,7 @@ export const ManageVault = ({ match }) => {
                 </div>
               </div>
               <div className="sm:col-span-2">
-                <div className="bg-white rounded-md shadow dark:bg-zinc-900">
+                <div className="bg-white rounded-md shadow dark:bg-zinc-800">
                   <div className="flex flex-col px-4 py-5 sm:p-6">
                     <div>
                       <div className="flex items-start justify-between">
@@ -1051,7 +1051,7 @@ export const ManageVault = ({ match }) => {
                 </div>
               </section>
               <div className="sm:col-span-2">
-                <div className="bg-white rounded-md shadow dark:bg-zinc-900">
+                <div className="bg-white rounded-md shadow dark:bg-zinc-800">
                   <div className="px-4 py-5 sm:p-6">
                     <div className="flex items-start justify-between">
                       <div>
@@ -1105,7 +1105,7 @@ export const ManageVault = ({ match }) => {
                   </div>
                 </div>
 
-                <div className="mt-4 bg-white divide-y divide-gray-200 shadow dark:bg-zinc-900 dark:divide-zinc-600 sm:rounded-md sm:overflow-hidden">
+                <div className="mt-4 bg-white divide-y divide-gray-200 shadow dark:bg-zinc-800 dark:divide-zinc-600 sm:rounded-md sm:overflow-hidden">
                   <div className="px-4 py-5 sm:p-6">
                     {loadingStackerData || loadingVaultData ? (
                       <>

--- a/web/components/mint.tsx
+++ b/web/components/mint.tsx
@@ -192,7 +192,7 @@ export const Mint = () => {
           ) : loadingVaults === true ? (
             <div className="min-w-full mt-4 overflow-hidden overflow-x-auto align-middle rounded-lg sm:shadow">
               <table className="min-w-full divide-y divide-gray-200 dark:divide-zinc-600">
-                <thead className="bg-gray-50 dark:bg-zinc-900 dark:bg-opacity-80">
+                <thead className="bg-gray-50 dark:bg-zinc-800 dark:bg-opacity-80">
                   <tr>
                     <th
                       scope="col"
@@ -203,12 +203,12 @@ export const Mint = () => {
                   </tr>
                 </thead>
                 <tbody>
-                  <tr className="bg-white dark:bg-zinc-900">
+                  <tr className="bg-white dark:bg-zinc-800">
                     <td className="px-6 py-4 text-sm text-left text-gray-500 whitespace-nowrap">
                       <Placeholder />
                     </td>
                   </tr>
-                  <tr className="bg-white dark:bg-zinc-900">
+                  <tr className="bg-white dark:bg-zinc-800">
                     <td className="px-6 py-4 text-sm text-left text-gray-500 whitespace-nowrap">
                       <Placeholder />
                     </td>

--- a/web/components/new-vault-wizard-nav.tsx
+++ b/web/components/new-vault-wizard-nav.tsx
@@ -39,11 +39,11 @@ export const NewVaultWizardNav = ({ currentSection, setStep }) => {
   });
 
   return (
-    <div className="relative overflow-hidden rounded-md lg:border-t lg:border-b lg:border-gray-200">
-      <nav className="bg-white" aria-label="New Vault Wizard Navigation">
+    <div className="relative overflow-hidden rounded-md lg:border-t lg:border-b lg:border-gray-200 dark:lg:border-zinc-600">
+      <nav className="bg-white dark:bg-zinc-800" aria-label="New Vault Wizard Navigation">
         <ol
           role="list"
-          className="overflow-hidden lg:flex lg:border-l lg:border-r lg:border-gray-200"
+          className="overflow-hidden lg:flex lg:border-l lg:border-r lg:border-gray-200 dark:lg:border-zinc-600"
         >
           {vaultCreationSections.map((section, sectionIdx) => (
             <li key={section.id} className="relative overflow-hidden lg:flex-1">
@@ -51,7 +51,7 @@ export const NewVaultWizardNav = ({ currentSection, setStep }) => {
                 className={classNames(
                   sectionIdx === 0 ? 'border-b-0' : '',
                   sectionIdx === vaultCreationSections.length - 1 ? 'border-t-0' : '',
-                  'border border-gray-200 overflow-hidden lg:border-0'
+                  'border border-gray-200 dark:border-zinc-600 overflow-hidden lg:border-0'
                 )}
               >
                 {section.status === 'complete' ? (
@@ -67,13 +67,13 @@ export const NewVaultWizardNav = ({ currentSection, setStep }) => {
                       )}
                     >
                       <span className="shrink-0">
-                        <span className="flex items-center justify-center w-10 h-10 bg-indigo-600 rounded-full">
-                          <CheckIcon className="w-6 h-6 text-white" aria-hidden="true" />
+                        <span className="flex items-center justify-center w-10 h-10 bg-indigo-600 rounded-full dark:bg-indigo-400">
+                          <CheckIcon className="w-6 h-6 text-white dark:text-zinc-700" aria-hidden="true" />
                         </span>
                       </span>
                       <span className="mt-0.5 ml-4 min-w-0 flex flex-col">
-                        <span className="text-base font-headings">{section.name}</span>
-                        <span className="text-sm font-medium text-gray-500">
+                        <span className="text-base text-left font-headings">{section.name}</span>
+                        <span className="text-sm font-medium text-gray-500 dark:text-zinc-400">
                           {section.description}
                         </span>
                       </span>
@@ -82,7 +82,7 @@ export const NewVaultWizardNav = ({ currentSection, setStep }) => {
                 ) : section.status === 'current' ? (
                   <RouterLink to={section.href} aria-current="step">
                     <span
-                      className="absolute top-0 left-0 w-1 h-full bg-indigo-600 lg:w-full lg:h-1 lg:bottom-0 lg:top-auto"
+                      className="absolute top-0 left-0 w-1 h-full bg-indigo-600 dark:bg-indigo-400 lg:w-full lg:h-1 lg:bottom-0 lg:top-auto"
                       aria-hidden="true"
                     />
                     <span
@@ -92,15 +92,15 @@ export const NewVaultWizardNav = ({ currentSection, setStep }) => {
                       )}
                     >
                       <span className="shrink-0">
-                        <span className="flex items-center justify-center w-10 h-10 border-2 border-indigo-600 rounded-full">
-                          <span className="font-semibold text-indigo-600">{section.id}</span>
+                        <span className="flex items-center justify-center w-10 h-10 border-2 border-indigo-600 rounded-full dark:border-indigo-400">
+                          <span className="font-semibold text-indigo-600 dark:text-indigo-400">{section.id}</span>
                         </span>
                       </span>
                       <span className="mt-0.5 ml-4 min-w-0 flex flex-col">
-                        <span className="text-base text-indigo-600 font-headings">
+                        <span className="text-base text-indigo-600 dark:text-indigo-400 font-headings">
                           {section.name}
                         </span>
-                        <span className="text-sm font-medium text-gray-500">
+                        <span className="text-sm font-medium text-gray-500 dark:text-zinc-400">
                           {section.description}
                         </span>
                       </span>
@@ -120,14 +120,14 @@ export const NewVaultWizardNav = ({ currentSection, setStep }) => {
                     >
                       <span className="shrink-0">
                         <span className="flex items-center justify-center w-10 h-10 border-2 border-gray-300 rounded-full">
-                          <span className="text-gray-500">{section.id}</span>
+                          <span className="text-gray-500 dark:text-zinc-400">{section.id}</span>
                         </span>
                       </span>
                       <span className="mt-0.5 ml-4 min-w-0 flex flex-col">
-                        <span className="text-base text-gray-500 font-headings">
+                        <span className="text-base text-gray-500 dark:text-zinc-400 font-headings">
                           {section.name}
                         </span>
-                        <span className="text-sm font-medium text-gray-500">
+                        <span className="text-sm font-medium text-gray-500 dark:text-zinc-400">
                           {section.description}
                         </span>
                       </span>
@@ -143,7 +143,7 @@ export const NewVaultWizardNav = ({ currentSection, setStep }) => {
                       aria-hidden="true"
                     >
                       <svg
-                        className="w-full h-full text-gray-300"
+                        className="w-full h-full text-gray-300 dark:text-zinc-700"
                         viewBox="0 0 12 82"
                         fill="none"
                         preserveAspectRatio="none"

--- a/web/components/pool.tsx
+++ b/web/components/pool.tsx
@@ -21,7 +21,7 @@ export const Pool: React.FC = () => {
   return (
     <Container>
       <main className="relative flex flex-col items-center justify-center flex-1 py-12 pb-8">
-        <div className="relative z-10 w-full max-w-lg bg-white rounded-lg shadow dark:bg-zinc-900">
+        <div className="relative z-10 w-full max-w-lg bg-white rounded-lg shadow dark:bg-zinc-800">
           <div className="flex flex-col p-4">
             <div className="mb-4">
               <div>

--- a/web/components/prices.tsx
+++ b/web/components/prices.tsx
@@ -144,8 +144,8 @@ export const Prices = () => {
       </header>
 
       <div className="min-w-full mt-4 overflow-hidden overflow-x-auto align-middle border border-gray-200 rounded-lg dark:border-zinc-600 lg:hidden">
-        <div className="bg-white dark:bg-zinc-900">
-          <div className="mx-auto bg-white dark:bg-zinc-900 sm:py-6 max-w-7xl">
+        <div className="bg-white dark:bg-zinc-800">
+          <div className="mx-auto bg-white dark:bg-zinc-800 sm:py-6 max-w-7xl">
             <div className="max-w-2xl mx-auto space-y-2 divide-y divide-gray-200 dark:divide-zinc-600">
               {assets.map(asset => (
                 <section className="pt-4" key={asset.token}>
@@ -228,7 +228,7 @@ export const Prices = () => {
           <div className="inline-block min-w-full py-2 align-middle sm:px-6 lg:px-8">
             <div className="overflow-hidden border border-gray-200 rounded-lg dark:border-zinc-700">
               <table className="min-w-full divide-y divide-gray-200 dark:divide-zinc-600">
-                <thead className="bg-gray-50 dark:bg-zinc-900 dark:bg-opacity-80">
+                <thead className="bg-gray-50 dark:bg-zinc-800 dark:bg-opacity-80">
                   <tr>
                     <th
                       scope="col"
@@ -250,9 +250,9 @@ export const Prices = () => {
                     </th>
                   </tr>
                 </thead>
-                <tbody className="bg-white divide-y divide-gray-200 dark:bg-zinc-900 dark:divide-zinc-600">
+                <tbody className="bg-white divide-y divide-gray-200 dark:bg-zinc-800 dark:divide-zinc-600">
                   {assets.map(asset => (
-                    <tr key={asset.token} className="bg-white dark:bg-zinc-900">
+                    <tr key={asset.token} className="bg-white dark:bg-zinc-800">
                       <td className="px-6 py-4 text-sm text-gray-900 dark:text-zinc-100 whitespace-nowrap">
                         <div className="flex items-center">
                           <div className="w-10 h-10 shrink-0">

--- a/web/components/proposal-group.tsx
+++ b/web/components/proposal-group.tsx
@@ -40,7 +40,7 @@ export const ProposalGroup: React.FC<ProposalProps[]> = ({ proposals }) => {
   proposalItems.sort((a, b) => (a.endBlockHeight > b.endBlockHeight) ? 1 : -1);
 
   return (
-    <div className="mt-5 overflow-hidden bg-white rounded-md shadow dark:bg-zinc-900">
+    <div className="mt-5 overflow-hidden bg-white rounded-md shadow dark:bg-zinc-800">
       <ul className="divide-y divide-gray-200 dark:divide-zinc-600">{proposalItems}</ul>
     </div>
   );

--- a/web/components/remove-swap-liquidity.tsx
+++ b/web/components/remove-swap-liquidity.tsx
@@ -229,7 +229,7 @@ export const RemoveSwapLiquidity: React.FC = ({ match }) => {
                 </span>
               </RouterLink>
             </p>
-            <div className="relative z-10 w-full max-w-lg bg-white rounded-lg shadow dark:bg-zinc-900">
+            <div className="relative z-10 w-full max-w-lg bg-white rounded-lg shadow dark:bg-zinc-800">
               <div className="flex flex-col p-4">
                 <div className="flex justify-between mb-4">
                   <div>
@@ -332,7 +332,7 @@ export const RemoveSwapLiquidity: React.FC = ({ match }) => {
                 </div>
 
                 <form className="mt-4">
-                  <div className="border border-gray-200 rounded-md shadow-sm bg-gray-50 hover:border-gray-300 focus-within:border-indigo-200 dark:border-zinc-600 dark:bg-zinc-800 dark:hover:border-zinc-900 dark:focus-within:border-indigo-200">
+                  <div className="border border-gray-200 rounded-md shadow-sm bg-gray-50 hover:border-gray-300 focus-within:border-indigo-200 dark:border-zinc-600 dark:bg-zinc-900 dark:hover:border-zinc-900 dark:focus-within:border-indigo-200">
                     <div className="flex items-center p-4">
                       <div className="lg:flex lg:items-start lg:flex-1 lg:justify-between">
                         <label
@@ -355,7 +355,7 @@ export const RemoveSwapLiquidity: React.FC = ({ match }) => {
                               placeholder="0.0"
                               value={percentageToRemove}
                               onChange={onInputChange}
-                              className="block p-0 pr-4 m-0 text-3xl font-semibold text-right text-gray-700 truncate border-0 focus:outline-none focus:ring-0 bg-gray-50 dark:bg-zinc-800 dark:text-zinc-200 w-52"
+                              className="block p-0 pr-4 m-0 text-3xl font-semibold text-right text-gray-700 truncate border-0 focus:outline-none focus:ring-0 bg-gray-50 dark:bg-zinc-900 dark:text-zinc-200 w-52"
                               style={{ appearance: 'textfield' }}
                             />
                             <div className="absolute inset-y-0 right-0 flex items-end pb-1 pointer-events-none">
@@ -410,7 +410,7 @@ export const RemoveSwapLiquidity: React.FC = ({ match }) => {
                     <ArrowDownIcon className="w-6 h-6 text-gray-500" aria-hidden="true" />
                   </div>
 
-                  <div className="border border-gray-200 rounded-md shadow-sm bg-gray-50 hover:border-gray-300 focus-within:border-indigo-200 dark:border-zinc-600 dark:bg-zinc-800 dark:hover:border-zinc-900 dark:focus-within:border-indigo-200">
+                  <div className="border border-gray-200 rounded-md shadow-sm bg-gray-50 hover:border-gray-300 focus-within:border-indigo-200 dark:border-zinc-600 dark:bg-zinc-900 dark:hover:border-zinc-900 dark:focus-within:border-indigo-200">
                     <div className="p-4">
                       <p className="text-base text-gray-700 dark:text-zinc-200">You will receive</p>
 

--- a/web/components/smart-contract-balance.tsx
+++ b/web/components/smart-contract-balance.tsx
@@ -94,7 +94,7 @@ export const SmartContractBalance = ({ address, description, name }) => {
   }, []);
 
   return (
-    <tr className="bg-white dark:bg-zinc-900">
+    <tr className="bg-white dark:bg-zinc-800">
       <td className="px-6 py-4 text-sm text-left text-gray-500 whitespace-nowrap">
         <div className="flex items-center">
           {name}

--- a/web/components/stake-actions.tsx
+++ b/web/components/stake-actions.tsx
@@ -27,7 +27,7 @@ export const StakeActions: React.FC<StakeActionsProps> = ({ children }) => {
           >
             <Menu.Items
               static
-              className="absolute top-0 z-10 w-48 mx-3 mt-1 origin-top-right bg-white divide-y divide-gray-200 dark:bg-zinc-900 dark:divide-zinc-600 rounded-md shadow-lg right-7 ring-1 ring-black ring-opacity-5 focus:outline-none"
+              className="absolute top-0 z-10 w-48 mx-3 mt-1 origin-top-right bg-white divide-y divide-gray-200 dark:bg-zinc-800 dark:divide-zinc-600 rounded-md shadow-lg right-7 ring-1 ring-black ring-opacity-5 focus:outline-none"
             >
               <div className="px-1 py-1">{children}</div>
             </Menu.Items>

--- a/web/components/stake-lp-row.tsx
+++ b/web/components/stake-lp-row.tsx
@@ -26,10 +26,10 @@ export const StakeLpRow: React.FC<StakeLpRowProps> = ({
   getLpRoute,
 }) => {
   return (
-    <Disclosure as="tbody" className="bg-white dark:bg-zinc-900">
+    <Disclosure as="tbody" className="bg-white dark:bg-zinc-800">
       {({ open }) => (
         <>
-          <tr className="bg-white dark:bg-zinc-900">
+          <tr className="bg-white dark:bg-zinc-800">
             <td className="px-6 py-4 text-sm whitespace-nowrap">
               <div className="flex flex-wrap items-center flex-1 sm:flex-nowrap">
                 <div className="flex -space-x-2 shrink-0">
@@ -167,7 +167,7 @@ export const StakeLpRow: React.FC<StakeLpRowProps> = ({
               )}
             </td>
             <td className="px-6 py-4 text-sm text-right whitespace-nowrap">
-              <Disclosure.Button className="inline-flex items-center justify-center px-2 py-1 text-sm text-indigo-500 bg-white rounded-lg focus:outline-none focus-visible:ring focus-visible:ring-indigo-500 focus-visible:ring-opacity-75 dark:bg-zinc-900 dark:text-indigo-400">
+              <Disclosure.Button className="inline-flex items-center justify-center px-2 py-1 text-sm text-indigo-500 bg-white rounded-lg focus:outline-none focus-visible:ring focus-visible:ring-indigo-500 focus-visible:ring-opacity-75 dark:bg-zinc-800 dark:text-indigo-400">
                 <span>Actions</span>
                 <ChevronUpIcon
                   className={`${

--- a/web/components/stake.tsx
+++ b/web/components/stake.tsx
@@ -941,7 +941,7 @@ export const Stake = () => {
                 </div>
               </header>
 
-              <div className="mt-4 bg-white divide-y divide-gray-200 rounded-md shadow dark:divide-gray-600 dark:bg-zinc-900">
+              <div className="mt-4 bg-white divide-y divide-gray-200 rounded-md shadow dark:divide-gray-600 dark:bg-zinc-800">
                 <div className="px-4 py-5 space-y-6 divide-y divide-gray-200 dark:divide-zinc-600 sm:p-6">
                   <div className="md:grid md:grid-flow-col gap-4 sm:grid-cols-[min-content,auto]">
                     <div className="self-center w-14">
@@ -1033,7 +1033,7 @@ export const Stake = () => {
                       <Menu as="div" className="relative flex items-center justify-end">
                         {({ open }) => (
                           <>
-                            <Menu.Button className="inline-flex items-center justify-center px-2 py-1 text-sm text-indigo-500 bg-white rounded-lg focus:outline-none focus-visible:ring focus-visible:ring-indigo-500 focus-visible:ring-opacity-75 dark:bg-zinc-900 dark:text-indigo-400">
+                            <Menu.Button className="inline-flex items-center justify-center px-2 py-1 text-sm text-indigo-500 bg-white rounded-lg focus:outline-none focus-visible:ring focus-visible:ring-indigo-500 focus-visible:ring-opacity-75 dark:bg-zinc-800 dark:text-indigo-400">
                               <span>Actions</span>
                               <ChevronUpIcon
                                 className={`${
@@ -1212,7 +1212,7 @@ export const Stake = () => {
                   <div className="inline-block min-w-full py-2 align-middle sm:px-6 lg:px-8">
                     <div className="overflow-hidden border border-gray-200 rounded-lg dark:border-zinc-700">
                       <table className="min-w-full divide-y divide-gray-200 dark:divide-zinc-600">
-                        <thead className="bg-gray-50 dark:bg-zinc-900 dark:bg-opacity-80">
+                        <thead className="bg-gray-50 dark:bg-zinc-800 dark:bg-opacity-80">
                           <tr>
                             <th
                               scope="col"

--- a/web/components/swap-loading-placeholder.tsx
+++ b/web/components/swap-loading-placeholder.tsx
@@ -8,7 +8,7 @@ export const SwapLoadingPlaceholder: React.FC = ({ tokenX, tokenY }) => {
   return (
     <>
       <div>
-        <div className="border border-gray-200 rounded-md shadow-sm bg-gray-50 hover:border-gray-300 focus-within:border-indigo-200 h-[104px] dark:border-zinc-800 dark:bg-zinc-800 dark:border-zinc-900">
+        <div className="border border-gray-200 rounded-md shadow-sm bg-gray-50 hover:border-gray-300 focus-within:border-indigo-200 h-[104px] dark:border-zinc-800 dark:bg-zinc-900 dark:border-zinc-900">
           <div className="flex items-center p-4 pb-2">
             <TokenSwapList selected={tokenX} setSelected={() => {}} disabled={true} />
           </div>
@@ -18,11 +18,11 @@ export const SwapLoadingPlaceholder: React.FC = ({ tokenX, tokenY }) => {
           </div>
         </div>
 
-        <div className="relative z-10 flex items-center justify-center w-8 h-8 -mt-4 -mb-4 -ml-4 text-gray-400 transform bg-white border border-gray-300 rounded-md dark:bg-zinc-900 left-1/2 focus:outline-none focus:ring-offset-0 focus:ring-1 focus:ring-indigo-500 dark:border-zinc-800">
+        <div className="relative z-10 flex items-center justify-center w-8 h-8 -mt-4 -mb-4 -ml-4 text-gray-400 transform bg-white border border-gray-300 rounded-md dark:bg-zinc-800 left-1/2 focus:outline-none focus:ring-offset-0 focus:ring-1 focus:ring-indigo-500 dark:border-zinc-800">
           <SwitchVerticalIcon className="w-5 h-5" aria-hidden="true" />
         </div>
 
-        <div className="mt-1 border border-gray-200 rounded-md shadow-sm bg-gray-50 hover:border-gray-300 focus-within:border-indigo-200 h-[104px] dark:border-zinc-800 dark:bg-zinc-800 dark:border-zinc-900">
+        <div className="mt-1 border border-gray-200 rounded-md shadow-sm bg-gray-50 hover:border-gray-300 focus-within:border-indigo-200 h-[104px] dark:border-zinc-800 dark:bg-zinc-900 dark:border-zinc-900">
           <div className="flex items-center p-4 pb-2">
             <TokenSwapList selected={tokenY} setSelected={() => {}} disabled={true} />
           </div>

--- a/web/components/swap-settings.tsx
+++ b/web/components/swap-settings.tsx
@@ -45,7 +45,7 @@ export const SwapSettings: React.FC<Props> = ({
           >
             <Popover.Panel className="absolute right-0 z-20 w-screen max-w-sm px-4 mt-3 sm:px-0">
               <div className="overflow-hidden rounded-lg shadow-lg ring-1 ring-black ring-opacity-5">
-                <div className="relative p-4 bg-white dark:bg-zinc-900">
+                <div className="relative p-4 bg-white dark:bg-zinc-800">
                   <div className="inline-flex items-center">
                     <h4 className="text-base font-medium leading-6 text-gray-900 font-headings dark:text-zinc-50">
                       Slippage Tolerance

--- a/web/components/swap.tsx
+++ b/web/components/swap.tsx
@@ -336,7 +336,7 @@ export const Swap: React.FC = () => {
 
       <Container>
         <main className="relative flex flex-col items-center justify-center flex-1 py-12 pb-8">
-          <div className="relative z-10 w-full max-w-lg bg-white rounded-lg shadow dark:bg-zinc-900">
+          <div className="relative z-10 w-full max-w-lg bg-white rounded-lg shadow dark:bg-zinc-800">
             <div className="flex flex-col p-4">
               <div className="flex justify-between mb-4">
                 <div>
@@ -389,7 +389,7 @@ export const Swap: React.FC = () => {
               ) : (
                 <>
                   <form>
-                    <div className="border border-gray-200 rounded-md shadow-sm bg-gray-50 hover:border-gray-300 focus-within:border-indigo-200 dark:border-zinc-600 dark:bg-zinc-800 dark:hover:border-zinc-900 dark:focus-within:border-indigo-200">
+                    <div className="border border-gray-200 rounded-md shadow-sm bg-gray-50 hover:border-gray-300 focus-within:border-indigo-200 dark:border-zinc-600 dark:bg-zinc-900 dark:hover:border-zinc-900 dark:focus-within:border-indigo-200">
                       <div className="flex items-center p-4 pb-2">
                         <TokenSwapList selected={tokenX} setSelected={setupTokenX} />
 
@@ -409,7 +409,7 @@ export const Swap: React.FC = () => {
                           value={tokenXAmount || ''}
                           onChange={onInputChange}
                           min={0}
-                          className="flex-1 p-0 m-0 ml-4 text-xl font-semibold text-right text-gray-800 truncate border-0 focus:outline-none focus:ring-0 bg-gray-50 dark:bg-zinc-800 dark:text-zinc-50"
+                          className="flex-1 p-0 m-0 ml-4 text-xl font-semibold text-right text-gray-800 truncate border-0 focus:outline-none focus:ring-0 bg-gray-50 dark:bg-zinc-900 dark:text-zinc-50"
                         />
                       </div>
 
@@ -443,12 +443,12 @@ export const Swap: React.FC = () => {
                     <button
                       type="button"
                       onClick={switchTokens}
-                      className="relative z-10 flex items-center justify-center w-8 h-8 -mt-4 -mb-4 -ml-4 text-gray-400 transform bg-white border border-gray-300 rounded-md dark:bg-zinc-900 left-1/2 hover:text-indigo-700 focus:outline-none focus:ring-offset-0 focus:ring-1 focus:ring-indigo-500 dark:border-zinc-800 dark:hover:text-indigo-400"
+                      className="relative z-10 flex items-center justify-center w-8 h-8 -mt-4 -mb-4 -ml-4 text-gray-400 transform bg-white border border-gray-300 rounded-md dark:bg-zinc-800 left-1/2 hover:text-indigo-700 focus:outline-none focus:ring-offset-0 focus:ring-1 focus:ring-indigo-500 dark:border-zinc-800 dark:hover:text-indigo-400"
                     >
                       <SwitchVerticalIcon className="w-5 h-5" aria-hidden="true" />
                     </button>
 
-                    <div className="mt-1 border border-gray-200 rounded-md shadow-sm bg-gray-50 hover:border-gray-300 focus-within:border-indigo-200 dark:border-zinc-600 dark:bg-zinc-800 dark:hover:border-zinc-900">
+                    <div className="mt-1 border border-gray-200 rounded-md shadow-sm bg-gray-50 hover:border-gray-300 focus-within:border-indigo-200 dark:border-zinc-600 dark:bg-zinc-900 dark:hover:border-zinc-900">
                       <div className="flex items-center p-4 pb-2">
                         <TokenSwapList selected={tokenY} setSelected={setupTokenY} />
 
@@ -470,7 +470,7 @@ export const Swap: React.FC = () => {
                           })}
                           onChange={onInputChange}
                           disabled={true}
-                          className="flex-1 p-0 m-0 ml-4 text-xl font-semibold text-right text-gray-800 truncate border-0 focus:outline-none focus:ring-0 bg-gray-50 dark:bg-zinc-800 dark:text-zinc-50"
+                          className="flex-1 p-0 m-0 ml-4 text-xl font-semibold text-right text-gray-800 truncate border-0 focus:outline-none focus:ring-0 bg-gray-50 dark:bg-zinc-900 dark:text-zinc-50"
                         />
                       </div>
 

--- a/web/components/token-swap-list.tsx
+++ b/web/components/token-swap-list.tsx
@@ -74,7 +74,7 @@ export const TokenSwapList: React.FC<Props> = ({ selected, setSelected, disabled
             <Listbox.Button
               className={`relative w-full py-2 pl-3 ${
                 disabled ? 'pr-3' : 'pr-10'
-              } text-left bg-white border border-gray-300 rounded-md shadow-sm cursor-default md:w-36 focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm dark:bg-zinc-900 dark:border-zinc-900`}
+              } text-left bg-white border border-gray-300 rounded-md shadow-sm cursor-default md:w-36 focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm dark:bg-zinc-800 dark:border-zinc-900`}
             >
               <span className="flex items-center">
                 <img src={selected.logo} alt="" className="w-6 h-6 rounded-full shrink-0" />
@@ -96,7 +96,7 @@ export const TokenSwapList: React.FC<Props> = ({ selected, setSelected, disabled
             >
               <Listbox.Options
                 static
-                className="absolute z-20 w-full py-1 mt-1 overflow-auto text-base bg-white rounded-md shadow-lg dark:text-zinc-50 dark:bg-zinc-900 max-h-56 ring-1 ring-black ring-opacity-5 focus:outline-none sm:text-sm"
+                className="absolute z-20 w-full py-1 mt-1 overflow-auto text-base bg-white rounded-md shadow-lg dark:text-zinc-50 dark:bg-zinc-800 max-h-56 ring-1 ring-black ring-opacity-5 focus:outline-none sm:text-sm"
               >
                 {tokenList
                   .filter(token => token.listed)

--- a/web/components/tx-sidebar.tsx
+++ b/web/components/tx-sidebar.tsx
@@ -142,7 +142,7 @@ export const TxSidebar = ({ showSidebar, setShowSidebar }) => {
               leaveTo="translate-x-full"
             >
               <div className="w-screen max-w-md">
-                <div className="flex flex-col h-full overflow-y-scroll bg-white shadow-xl dark:bg-zinc-900">
+                <div className="flex flex-col h-full overflow-y-scroll bg-white shadow-xl dark:bg-zinc-800">
                   <div className="px-4 py-6 bg-indigo-700 sm:px-6">
                     <div className="flex items-start justify-between">
                       <Dialog.Title className="text-lg text-white font-headings">
@@ -168,7 +168,7 @@ export const TxSidebar = ({ showSidebar, setShowSidebar }) => {
                   <div className="relative px-4 my-6 sm:px-6">
                     <div className="relative w-72">
                       <Listbox value={selectedNetworkKey} onChange={setSelectedNetworkKey}>
-                        <Listbox.Button className="relative w-full py-2 pl-3 pr-10 text-left bg-white border border-gray-300 rounded-md shadow-sm cursor-default focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm dark:bg-zinc-800 dark:border-zinc-800">
+                        <Listbox.Button className="relative w-full py-2 pl-3 pr-10 text-left bg-white border border-gray-300 rounded-md shadow-sm cursor-default focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm dark:bg-zinc-900 dark:border-zinc-800">
                           <span className="block truncate dark:text-zinc-50">
                             {selectedNetwork?.name}
                           </span>
@@ -182,7 +182,7 @@ export const TxSidebar = ({ showSidebar, setShowSidebar }) => {
                           leaveFrom="opacity-100"
                           leaveTo="opacity-0"
                         >
-                          <Listbox.Options className="absolute right-0 w-full py-1 mt-1 overflow-auto text-base bg-white rounded-md shadow-lg dark:text-zinc-50 dark:bg-zinc-800 max-h-56 ring-1 ring-black ring-opacity-5 focus:outline-none sm:text-sm">
+                          <Listbox.Options className="absolute right-0 w-full py-1 mt-1 overflow-auto text-base bg-white rounded-md shadow-lg dark:text-zinc-50 dark:bg-zinc-900 max-h-56 ring-1 ring-black ring-opacity-5 focus:outline-none sm:text-sm">
                             {networks.map(network => (
                               <Listbox.Option
                                 key={network.key}

--- a/web/components/ui/empty-state.tsx
+++ b/web/components/ui/empty-state.tsx
@@ -9,10 +9,10 @@ interface EmptyStateProps {
 export const EmptyState: React.FC<EmptyStateProps> = ({ Icon, title, description }) => {
   return (
     <div className="flex justify-center w-full mx-auto mt-12 md:w-2/3">
-      <div className="flow-root p-8 bg-gray-100 border-2 border-gray-300 border-dotted rounded-lg dark:bg-zinc-800 dark:border-500">
+      <div className="flow-root p-8 bg-gray-100 border-2 border-gray-300 border-dotted rounded-lg dark:bg-zinc-900 dark:border-500">
         <div className="relative">
           <div>
-            <div className="flex items-center justify-center w-16 h-16 mx-auto mb-4 text-gray-600 transform bg-gray-100 dark:text-zinc-400 dark:bg-zinc-800 md:absolute -rotate-12 md:-top-12 md:-left-16 md:mb-0">
+            <div className="flex items-center justify-center w-16 h-16 mx-auto mb-4 text-gray-600 transform bg-gray-100 dark:text-zinc-400 dark:bg-zinc-900 md:absolute -rotate-12 md:-top-12 md:-left-16 md:mb-0">
               <Icon className="w-12 h-12 text-gray-600 dark:text-zinc-400" aria-hidden="true" />
             </div>
             <p className="text-lg font-medium leading-6 text-gray-900 dark:text-zinc-100 md:ml-8">{title}</p>

--- a/web/components/ui/modal.tsx
+++ b/web/components/ui/modal.tsx
@@ -61,11 +61,11 @@ export function Modal({
             leaveFrom="opacity-100 translate-y-0 sm:scale-100"
             leaveTo="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
           >
-            <div className="inline-block px-4 pt-5 pb-4 overflow-hidden text-left align-bottom transition-all transform bg-white rounded-lg shadow-xl dark:bg-zinc-900 sm:my-8 sm:align-middle sm:max-w-lg sm:w-full sm:p-6">
+            <div className="inline-block px-4 pt-5 pb-4 overflow-hidden text-left align-bottom transition-all transform bg-white rounded-lg shadow-xl dark:bg-zinc-800 sm:my-8 sm:align-middle sm:max-w-lg sm:w-full sm:p-6">
               <div className="absolute top-0 right-0 hidden pt-4 pr-4 sm:block">
                 <button
                   type="button"
-                  className="text-gray-400 bg-white rounded-md dark:bg-zinc-900 hover:text-gray-500 dark:hover:text-zinc-400 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+                  className="text-gray-400 bg-white rounded-md dark:bg-zinc-800 hover:text-gray-500 dark:hover:text-zinc-400 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
                   onClick={closeModal}
                 >
                   <span className="sr-only">Close</span>

--- a/web/components/vault-group.tsx
+++ b/web/components/vault-group.tsx
@@ -35,7 +35,7 @@ export const VaultGroup: React.FC<VaultGroupProps> = ({ vaults }) => {
             <div className="inline-block min-w-full py-2 align-middle sm:px-6 lg:px-8">
               <div className="overflow-hidden border border-gray-200 rounded-lg dark:border-zinc-700">
                 <table className="min-w-full divide-y divide-gray-200 dark:divide-zinc-600">
-                  <thead className="bg-gray-50 dark:bg-zinc-900 dark:bg-opacity-80">
+                  <thead className="bg-gray-50 dark:bg-zinc-800 dark:bg-opacity-80">
                     <tr>
                       <th
                         scope="col"
@@ -81,7 +81,7 @@ export const VaultGroup: React.FC<VaultGroupProps> = ({ vaults }) => {
                       </th>
                     </tr>
                   </thead>
-                  <tbody className="bg-white divide-y divide-gray-200 dark:bg-zinc-900 dark:divide-zinc-600">{vaultItems}</tbody>
+                  <tbody className="bg-white divide-y divide-gray-200 dark:bg-zinc-800 dark:divide-zinc-600">{vaultItems}</tbody>
                 </table>
               </div>
             </div>

--- a/web/components/vault.tsx
+++ b/web/components/vault.tsx
@@ -93,7 +93,7 @@ export const Vault: React.FC<VaultProps> = ({
       return 'bg-red-300/50';
     }
 
-    return 'bg-white dark:bg-zinc-900';
+    return 'bg-white dark:bg-zinc-800';
   };
 
   let debtRatio = 0;
@@ -206,7 +206,7 @@ export const Vault: React.FC<VaultProps> = ({
           </td>
         </tr>
       ) : (
-        <div role="listitem" className="bg-white dark:bg-zinc-900">
+        <div role="listitem" className="bg-white dark:bg-zinc-800">
           <table className="w-full">
             <thead>
               <tr>

--- a/web/components/view-proposal.tsx
+++ b/web/components/view-proposal.tsx
@@ -356,7 +356,7 @@ export const ViewProposal = ({ match }) => {
       <Modal isOpen={showVoteDikoModal}>
         <div className="flex px-4 pt-4 pb-20 text-center sm:block sm:p-0">
           <div
-            className="inline-block px-2 pt-5 pb-4 overflow-hidden text-left align-bottom bg-white rounded-lg dark:bg-zinc-900 sm:my-8 sm:align-middle sm:max-w-sm sm:w-full sm:p-6"
+            className="inline-block px-2 pt-5 pb-4 overflow-hidden text-left align-bottom bg-white rounded-lg dark:bg-zinc-800 sm:my-8 sm:align-middle sm:max-w-sm sm:w-full sm:p-6"
             role="dialog"
             aria-modal="true"
             aria-labelledby="modal-headline"
@@ -563,7 +563,7 @@ export const ViewProposal = ({ match }) => {
 
           <div className="mt-4">
             <div className="space-y-4 lg:grid lg:grid-cols-2 lg:gap-x-4 lg:space-y-0">
-              <div className="overflow-hidden bg-white rounded-lg shadow dark:bg-zinc-900">
+              <div className="overflow-hidden bg-white rounded-lg shadow dark:bg-zinc-800">
                 <div className="px-4 py-5 sm:px-6">
                   <h3 className="text-lg font-medium leading-6 text-gray-900 font-headings dark:text-zinc-50">
                     Details
@@ -665,7 +665,7 @@ export const ViewProposal = ({ match }) => {
                 </div>
               </div>
 
-              <div className="flex flex-col overflow-hidden bg-white rounded-lg shadow dark:bg-zinc-900">
+              <div className="flex flex-col overflow-hidden bg-white rounded-lg shadow dark:bg-zinc-800">
                 <dl className="flex-1 sm:grid sm:grid-cols-2">
                   <div className="flex flex-col justify-center p-6 text-center border-b border-gray-200 dark:border-zinc-600 sm:border-0 sm:border-r">
                     <dt className="inline-flex items-center order-2 mx-auto mt-2 text-lg font-medium leading-6">
@@ -750,7 +750,7 @@ export const ViewProposal = ({ match }) => {
                     </dd>
                   </div>
                 </dl>
-                <div className="p-5 bg-white border-t border-gray-200 dark:bg-zinc-900 dark:border-zinc-600">
+                <div className="p-5 bg-white border-t border-gray-200 dark:bg-zinc-800 dark:border-zinc-600">
                   {isLoading ? (
                     <Placeholder
                       className="justify-center py-2"

--- a/web/public/html/index.html
+++ b/web/public/html/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" href="/assets/logo.png" />
   </head>
-  <body class="antialiased text-gray-600 dark:text-zinc-500">
+  <body class="antialiased text-gray-600 dark:text-zinc-400">
     <div id="app-root"></div>
   </body>
 </html>


### PR DESCRIPTION
As best practice:
> Depth: At higher levels of elevation, components express depth by displaying lighter surface colors

|Before|After|
|---|---|
|<img width="1252" alt="Screen Shot 2022-03-09 at 10 03 19 PM" src="https://user-images.githubusercontent.com/1909957/157544154-ee6df3da-c79c-4215-9558-2e8774e56f69.png">|<img width="1305" alt="Screen Shot 2022-03-09 at 10 04 38 PM" src="https://user-images.githubusercontent.com/1909957/157544138-1fdad6bf-6afe-47b5-a511-a8af34033406.png">|



