### PR TITLE
fix: show xSTX redeem box when no xSTX in wallet

### DIFF
--- a/web/components/liquidations.tsx
+++ b/web/components/liquidations.tsx
@@ -473,48 +473,52 @@ export const Liquidations: React.FC = () => {
         <Container>
           <main className="relative flex-1 py-12">
 
-            {state.balance['xstx'] > 0 ? (
-              <section>
-                <header className="pb-5 border-b border-gray-200 dark:border-zinc-600 sm:flex sm:justify-between sm:items-end">
-                  <div>
-                    <h3 className="text-lg leading-6 text-gray-900 font-headings dark:text-zinc-50">Trade xSTX for STX</h3>
-                  </div>
-                </header>
-                <div className="mt-4">
-                  {isLoading ? (
-                    <>
-                      <Placeholder className="py-2" width={Placeholder.width.FULL} />
-                      <Placeholder className="py-2" width={Placeholder.width.FULL} />
-                    </>
-                  ) : (
-                    <div className="mt-4 shadow sm:rounded-md sm:overflow-hidden">
-                      <div className="px-4 py-5 bg-white dark:bg-zinc-800 sm:p-6">
-                        {(redeemableStx / 1000000) === 0 ? (
-                          <>
-                            <p>There are <span className="font-semibold">no redeemable STX</span> in the Arkadiko pool.</p>
-                            <p className="mt-1">Be sure to check again later to redeem your xSTX for STX.</p>
-                          </>
-                        ) : (
-                          <p>There are <span className="text-lg font-semibold">{redeemableStx / 1000000}</span> STX redeemable in the Arkadiko pool.</p>
-                        )}
-                        <div className="flex items-center justify-between mt-4">
-                          <p>You have <span className="text-lg font-semibold">{state.balance['xstx'] / 1000000}</span> xSTX.</p>
+            <section>
+              <header className="pb-5 border-b border-gray-200 dark:border-zinc-600 sm:flex sm:justify-between sm:items-end">
+                <div>
+                  <h3 className="text-lg leading-6 text-gray-900 font-headings dark:text-zinc-50">Trade xSTX for STX</h3>
+                </div>
+              </header>
+              <div className="mt-4">
+                <div className="mt-4 shadow sm:rounded-md sm:overflow-hidden">
+                  <div className="px-4 py-5 bg-white dark:bg-zinc-800 sm:p-6">
+                    <div className="flex items-center justify-between">
+                      {isLoading ? (
+                        <>
+                          <Placeholder className="py-2" width={Placeholder.width.FULL} />
+                          <Placeholder className="py-2" width={Placeholder.width.FULL} />
+                        </>
+                      ) : (
+                        <>
+                          <p>
+                            You have <span className="text-lg font-semibold">{state.balance['xstx'] / 1000000}</span> xSTX. {' '}
+                            {redeemableStx != 0 ? (
+                              <>
+                                There are <span className="font-semibold">no redeemable STX</span> in the Arkadiko pool.
+                                Be sure to check again later.
+                              </>
+                            ) : (
+                              <>
+                                There are <span className="text-lg font-semibold">{redeemableStx / 1000000}</span> STX redeemable in the Arkadiko pool.
+                              </>
+                            )}
+                          </p>
 
                           <button
                             type="button"
                             onClick={() => redeemStx()}
-                            disabled={(redeemableStx / 1000000) === 0}
+                            disabled={redeemableStx == 0 || state.balance['xstx'] == 0}
                             className="inline-flex justify-center px-4 py-2 text-base font-medium text-white bg-indigo-600 border border-transparent rounded-md shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:col-start-2 sm:text-sm disabled:bg-gray-100 disabled:text-gray-500 disabled:cursor-not-allowed"
                           >
                             Redeem
                           </button>
-                        </div>
-                      </div>
+                        </>
+                      )}
                     </div>
-                  )}
+                  </div>
                 </div>
-              </section>
-            ): null}
+              </div>
+            </section>
 
             <section>
               <header className="pt-10 pb-5 border-b border-gray-200 dark:border-zinc-600 sm:flex sm:justify-between sm:items-end">


### PR DESCRIPTION
Small fix to always show xSTX redeem box, as people on Discord where confused about where to redeem xSTX..