### PR TITLE
fix: Remove concatenated classes for Collateral cards in Borrow section

### DIFF
--- a/web/components/collateral-card.tsx
+++ b/web/components/collateral-card.tsx
@@ -40,12 +40,26 @@ export const CollateralCard: React.FC<CollateralTypeProps> = ({ types }) => {
       'STX-A': {
         label: 'Keep stacking while borrowing',
         logo: '/assets/tokens/stx.svg',
-        path: '/vaults/new#stx'
+        path: '/vaults/new#stx',
+        classes: {
+          wrapper: 'border-STX/5 hover:border-STX/10 shadow-STX/10 from-STX/5 to-STX/10',
+          tokenShadow: 'shadow-STX/10',
+          innerBg: 'bg-STX',
+          iconColor: 'text-STX/80',
+          innerText: 'text-STX'
+        }
       },
       'XBTC-A': {
         label: 'Borrow against the hardest money',
         logo: '/assets/tokens/xbtc.svg',
-        path: '/vaults/new?type=xBTC-A&token=xBTC'
+        path: '/vaults/new?type=xBTC-A&token=xBTC',
+        classes: {
+          wrapper: 'border-xBTC/5 hover:border-xBTC/10 shadow-xBTC/10 from-xBTC/5 to-xBTC/10',
+          tokenShadow: 'shadow-xBTC/10',
+          innerBg: 'bg-xBTC',
+          iconColor: 'text-xBTC/80',
+          innerText: 'text-xBTC'
+        }
       },
       //'atAlex': {
       //   label: 'Random catch phrase here',
@@ -69,7 +83,8 @@ export const CollateralCard: React.FC<CollateralTypeProps> = ({ types }) => {
         maximumDebt: coll['maximumDebt'],
         label: collExtraInfo[tokenString]?.['label'],
         logo: collExtraInfo[tokenString]?.['logo'],
-        path: collExtraInfo[tokenString]?.['path']
+        path: collExtraInfo[tokenString]?.['path'],
+        classes: collExtraInfo[tokenString]?.['classes']
       });
     }
   });
@@ -77,22 +92,22 @@ export const CollateralCard: React.FC<CollateralTypeProps> = ({ types }) => {
   return (
     <>
       {collateralItems.map((collateral) => (
-        <div key={collateral.tokenType} className={`group border border-${collateral.token}/5 hover:border-${collateral.token}/10 shadow-md shadow-${collateral.token}/10 flex flex-col col-span-1 bg-gradient-to-br from-${collateral.token}/5 to-${collateral.token}/10 divide-y divide-gray-200 rounded-md transition duration-700 ease-in-out sm:w-1/3`}>
+        <div key={collateral.tokenType} className={`group border shadow-md ${collateral.classes.wrapper} flex flex-col col-span-1 bg-gradient-to-br divide-y divide-gray-200 rounded-md transition duration-700 ease-in-out sm:w-1/3`}>
           <div className="flex flex-col flex-1 px-6 py-8">
             <div className="flex items-start justify-between">
               <div className="mr-6">
                 <h2 className="text-xl font-medium font-semibold leading-6 text-gray-700 dark:text-zinc-100">{collateral.token}</h2>
                 <p className="mt-1.5">{collateral.label}</p>
               </div>
-              <div className={`flex items-center justify-center w-20 h-20 shrink-0 origin-bottom bg-white/80 rounded-md shadow-2xl shadow-${collateral.token}/10 rotate-6 scale-[0.95] transition duration-700 ease-in-out group-hover:rotate-0 group-hover:scale-100 group-hover:-translate-y-1 border border-gray-400/30`}>
+              <div className={`flex items-center justify-center w-20 h-20 shrink-0 origin-bottom bg-white/80 rounded-md shadow-2xl ${collateral.classes.tokenShadow} rotate-6 scale-[0.95] transition duration-700 ease-in-out group-hover:rotate-0 group-hover:scale-100 group-hover:-translate-y-1 border border-gray-400/30`}>
                 <img className="w-12 h-12" src={collateral.logo} alt="" />
               </div>
             </div>
 
-            <div className={`px-4 py-5 mt-8 mb-4 rounded-lg bg-${collateral.token} bg-opacity-[.08] flex items-center justify-center`}>
-              <StyledIcon as="SparklesIcon" size={6} className={`brightness-50 dark:brightness-100 text-${collateral.token}/80 mr-6 shrink-0`} />
+            <div className={`px-4 py-5 mt-8 mb-4 rounded-lg ${collateral.classes.innerBg} bg-opacity-[.08] flex items-center justify-center`}>
+              <StyledIcon as="SparklesIcon" size={6} className={`brightness-50 dark:brightness-100 ${collateral.classes.iconColor} mr-6 shrink-0`} />
               <div className="flex flex-col">
-                <p className={`text-sm font-semibold brightness-75 text-${collateral.token}`}>
+                <p className={`text-sm font-semibold brightness-75 ${collateral.classes.innerText}`}>
                   With{' '}
                   {collateral.token === "STX" ?
                       state.userData && state.balance["stx"] > 0 ?
@@ -116,7 +131,7 @@ export const CollateralCard: React.FC<CollateralTypeProps> = ({ types }) => {
                   <span className="text-xs">
                     {' '}{collateral.token}
                   </span>,</p>
-                <p className={`text-lg font-semibold text-${collateral.token} brightness-50 dark:brightness-100`}>
+                <p className={`text-lg font-semibold ${collateral.classes.innerText} brightness-50 dark:brightness-100`}>
                   borrow up to {' '}
 
                   {collateral.token === "STX" ?

--- a/web/tailwind.config.js
+++ b/web/tailwind.config.js
@@ -8,11 +8,6 @@ module.exports = {
     './components/**/*.tsx',
     './public/html/*.html'
   ],
-  safelist: [
-    { pattern: /STX/ },
-    { pattern: /xBTC/ },
-    { pattern: /atAlex/ },
-  ],
   theme: {
     extend: {
       fontFamily: {


### PR DESCRIPTION
Apparently Tailwind's JIT engine doesn't see concatenated classes.
