### PR TITLE
feat: display balances on smaller resolutions

### DIFF
--- a/web/components/balances.tsx
+++ b/web/components/balances.tsx
@@ -1,0 +1,66 @@
+import React, { useContext } from 'react';
+import { AppContext } from '@common/context';
+import { microToReadable } from '@common/vault-utils';
+
+
+export const Balances = () => {
+  const [state, _] = useContext(AppContext);
+  return (
+    <span className="space-y-1 sm:space-y-0 sm:space-x-6">
+      <span className="block text-sm sm:mt-0 sm:inline-block">
+        <span className="font-semibold">
+          {microToReadable(state.balance['stx']).toLocaleString(undefined, {
+            minimumFractionDigits: 2,
+            maximumFractionDigits: 6,
+          })}
+        </span>{' '}
+        <span className="opacity-75">STX</span>
+      </span>
+      <span className="block text-sm sm:mt-0 sm:inline-block">
+        <span className="font-semibold">
+          {(parseFloat(state.balance['xbtc']) / 100000000).toLocaleString(undefined, {
+            minimumFractionDigits: 2,
+            maximumFractionDigits: 6,
+          })}
+        </span>{' '}
+        <span className="opacity-75">xBTC</span>
+      </span>
+      <span className="block text-sm sm:mt-0 sm:inline-block">
+        <span className="font-semibold">
+          {microToReadable(state.balance['usda']).toLocaleString(undefined, {
+            minimumFractionDigits: 2,
+            maximumFractionDigits: 6,
+          })}
+        </span>{' '}
+        <span className="opacity-75">USDA</span>
+      </span>
+      <span className="block text-sm sm:mt-0 sm:inline-block">
+        <span className="font-semibold">
+          {microToReadable(state.balance['auto-alex'] / 100).toLocaleString(undefined, {
+            minimumFractionDigits: 2,
+            maximumFractionDigits: 6,
+          })}
+        </span>{' '}
+        <span className="opacity-75">atALEX</span>
+      </span>
+      <span className="block text-sm sm:mt-0 sm:inline-block">
+        <span className="font-semibold">
+          {microToReadable(state.balance['diko']).toLocaleString(undefined, {
+            minimumFractionDigits: 2,
+            maximumFractionDigits: 6,
+          })}
+        </span>{' '}
+        <span className="opacity-75">DIKO</span>
+      </span>
+      <span className="block text-sm sm:mt-0 sm:inline-block">
+        <span className="font-semibold">
+          {microToReadable(state.balance['stdiko']).toLocaleString(undefined, {
+            minimumFractionDigits: 2,
+            maximumFractionDigits: 6,
+          })}
+        </span>{' '}
+        <span className="opacity-75">stDIKO</span>
+      </span>
+    </span>
+  );
+};

--- a/web/components/sub-header.tsx
+++ b/web/components/sub-header.tsx
@@ -1,75 +1,46 @@
-import React, { useContext } from 'react';
-import { AppContext } from '@common/context';
-import { microToReadable } from '@common/vault-utils';
+import React from 'react';
+import { Disclosure } from '@headlessui/react';
+import { StyledIcon } from './ui/styled-icon';
+import { Balances } from './balances';
 
 export const SubHeader: React.FC = () => {
-  const [state, _] = useContext(AppContext);
-
   return (
-    <div className="relative hidden bg-indigo-500 sm:block dark:bg-indigo-300">
-      <div className="px-3 py-3 mx-auto max-w-7xl sm:px-6 lg:px-8">
-        <div className="pr-16 sm:text-center sm:px-16">
-          <p className="text-white dark:text-indigo-600">
-            <span className="mr-6 text-xs font-semibold uppercase">Balance:</span>
-            <span className="space-y-1 sm:space-y-0 sm:space-x-6">
-              <span className="block text-sm sm:mt-0 sm:inline-block">
-                <span className="font-semibold">
-                  {microToReadable(state.balance['stx']).toLocaleString(undefined, {
-                    minimumFractionDigits: 2,
-                    maximumFractionDigits: 6,
-                  })}
-                </span>{' '}
-                <span className="opacity-75">STX</span>
-              </span>
-              <span className="block text-sm sm:mt-0 sm:inline-block">
-                <span className="font-semibold">
-                  {(parseFloat(state.balance['xbtc']) / 100000000).toLocaleString(undefined, {
-                    minimumFractionDigits: 2,
-                    maximumFractionDigits: 6,
-                  })}
-                </span>{' '}
-                <span className="opacity-75">xBTC</span>
-              </span>
-              <span className="block text-sm sm:mt-0 sm:inline-block">
-                <span className="font-semibold">
-                  {microToReadable(state.balance['usda']).toLocaleString(undefined, {
-                    minimumFractionDigits: 2,
-                    maximumFractionDigits: 6,
-                  })}
-                </span>{' '}
-                <span className="opacity-75">USDA</span>
-              </span>
-              <span className="block text-sm sm:mt-0 sm:inline-block">
-                <span className="font-semibold">
-                  {microToReadable(state.balance['auto-alex'] / 100).toLocaleString(undefined, {
-                    minimumFractionDigits: 2,
-                    maximumFractionDigits: 6,
-                  })}
-                </span>{' '}
-                <span className="opacity-75">atALEX</span>
-              </span>
-              <span className="block text-sm sm:mt-0 sm:inline-block">
-                <span className="font-semibold">
-                  {microToReadable(state.balance['diko']).toLocaleString(undefined, {
-                    minimumFractionDigits: 2,
-                    maximumFractionDigits: 6,
-                  })}
-                </span>{' '}
-                <span className="opacity-75">DIKO</span>
-              </span>
-              <span className="block text-sm sm:mt-0 sm:inline-block">
-                <span className="font-semibold">
-                  {microToReadable(state.balance['stdiko']).toLocaleString(undefined, {
-                    minimumFractionDigits: 2,
-                    maximumFractionDigits: 6,
-                  })}
-                </span>{' '}
-                <span className="opacity-75">stDIKO</span>
-              </span>
-            </span>
-          </p>
+    <>
+      <div className="w-full sm:hidden">
+        <div className="w-full p-2 mx-auto bg-indigo-500 dark:bg-indigo-300">
+          <Disclosure>
+            {({ open }) => (
+              <>
+                <Disclosure.Button className="flex justify-between w-full px-4 py-2 text-sm font-medium text-left text-indigo-900 rounded-md hover:bg-indigo-600 dark:hover:bg-indigo-200 focus:outline-none focus-visible:ring focus-visible:ring-indigo-500 focus-visible:ring-opacity-75">
+                  <span className="mr-6 text-xs font-semibold text-white uppercase dark:text-indigo-600">Balances</span>
+                  <StyledIcon
+                    as="ChevronUpIcon"
+                    size={5}
+                    className={`${
+                      open ? 'rotate-180 transform' : ''
+                    } h-5 w-5 text-white dark:text-indigo-600`}
+                  />
+                </Disclosure.Button>
+                <Disclosure.Panel className="px-4 pt-4 pb-2 text-sm text-gray-500">
+                  <p className="text-white dark:text-indigo-600">
+                    <Balances />
+                  </p>
+                </Disclosure.Panel>
+              </>
+            )}
+          </Disclosure>
         </div>
       </div>
-    </div>
+      <div className="relative hidden bg-indigo-500 sm:block dark:bg-indigo-300">
+        <div className="px-3 py-3 mx-auto max-w-7xl sm:px-6 lg:px-8">
+          <div className="pr-16 sm:text-center sm:px-16">
+            <p className="text-white dark:text-indigo-600">
+              <span className="mr-6 text-xs font-semibold uppercase">Balances:</span>
+              <Balances />
+            </p>
+          </div>
+        </div>
+      </div>
+    </>
   );
 };


### PR DESCRIPTION
Before that, balances on mobile were just hidden.

https://user-images.githubusercontent.com/1909957/227571956-3a25d1cd-5587-4480-99a0-d4a5993773d2.mov

