### PR TITLE
fix: tooltip styling

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -46,6 +46,15 @@
 @tailwind base;
 @tailwind components;
 
+.portal > div[role="tooltip"].isdTly {
+  background-color: black;
+  padding-top: 6px;
+  padding-right: 8px;
+  padding-left: 8px;
+  padding-bottom: 6px;
+  font-size: 14px;
+}
+
 .draw-arrow {
   stroke-width: 5;
   stroke-dasharray: 400;


### PR DESCRIPTION
Quite a dirty fix actually. 
The tooltip library is probably very outdated but not sure why it broke.
We could replace it at some point.